### PR TITLE
fix: crash when openlibrary fails to find book

### DIFF
--- a/ubiblio/main.py
+++ b/ubiblio/main.py
@@ -451,16 +451,23 @@ def searchbookTitle(request: Request, user: schemas.User = Depends(get_current_u
 # --------------------------------------------------------------------------
 # ISBN autoadd
 # --------------------------------------------------------------------------
+def get_metadata(isbn: str, service: str):
+    try:
+        book = meta(isbn, service=service)
+        if "Title" in book:
+            return book
+    except Exception as e:
+        print(e)
+
+    return None
+
 @app.get("/isbn/{isbn}", dependencies=[get_rate_limiter(times=2, seconds=2)], response_class=HTMLResponse)
 def new_isbn(isbn, request: Request, user: schemas.User = Depends(get_current_user_from_token)):
     try:
         if user.isAdmin == True:
-            book = meta(isbn,service='goob')
-            if not "Title" in book:
-                book = meta(isbn,service='openl')
-            if not "Title" in book:
-                book = meta(isbn,service='wiki')
-                print(book["Title"])
+            book = meta(isbn,service='goob') or meta(isbn,service="openl") or meta(isbn,service='wiki')
+            if book is None:
+                raise LookupError(f"Book with isbn {isbn} not found!")
             title = book["Title"]
             author = book["Authors"][0]
             try:


### PR DESCRIPTION
The OpenLibrary source from `isbnlib` throws an error if the book is not found, e.g. reproducible with the ISBN `978-3839224243`. This PR catches such errors, thus allowing the `wiki` source to be tried as well to properly find the book.

PS: I'm opening the PR here to catch the error instead of at the `isbnlib` repository, because the library seems unmaintained, and chances of getting my PR merged there are probably not that high.