### PR TITLE
fix: crash when parent directory of secret key file doesn't exist

### DIFF
--- a/ubiblio/vars.py
+++ b/ubiblio/vars.py
@@ -30,6 +30,7 @@ else:
     secret_key = (
         subprocess.check_output(["openssl", "rand", "-hex", "32"]).decode().strip()
     )
+    os.makedirs(os.path.dirname(SECRET_KEY_FILE), exist_ok=True)
     with open(SECRET_KEY_FILE, "w+") as f:
         f.write(secret_key)
 


### PR DESCRIPTION
This for example happens if you don't provide any config directory and run `docker run -p 8000:8000 ubiblio` as per `SETUP.md`.

Thus we now create all the parent directories of `SECRET_KEY_FILE`, if they don't yet exist.