### PR TITLE
feat: admin config to set list of book genres

### DIFF
--- a/templates/config.html
+++ b/templates/config.html
@@ -75,6 +75,11 @@
 			(empty to disable): </label></p>
         <input type="text" name="customFieldName2" value="{{ config.customFieldName2 }}">
     </p>
+
+    <p>
+        <p><label for="">Genres (comma-separated): </label></p>
+        <input type="text" name="genres" value="{{ config.genres }}">
+    </p>
     </div>
     <div style= "display:block; clear:both;float:none;">
     <input  type="submit" value="Submit">

--- a/templates/newBook.html
+++ b/templates/newBook.html
@@ -77,18 +77,11 @@
     <p>
         <p><label for="">Genre</label></p>
         <select name="genre" id="genre">
-			<option value="Uncategorized" selected="selected">Uncategorized</option>
-  <option value="Sci-Fi">Sci-Fi</option>
-  <option value="Fantasy">Fantasy</option>
-<option value="Classic">Classic</option>
-			<option value="Reference">Reference</option>
-			<option value="Young Adult">Young Adult</option>
-			<option value="Historical Fiction">Historical Fiction</option>
-			<option value="Mystery">Mystery</option>
-			<option value="Anthology">Anthology</option>
-			<option value="Horror">Horror</option>
-			<option value="Romance">Romance</option>
-			<option value="Animal Fiction">Animal Fiction</option>
+					<option value="Uncategorized" selected="selected">Uncategorized</option>
+					{% for genre in config.genres.split(",") %}
+						<option value="{{ genre }}">{{ genre }}</option>
+					{% endfor %}
+				</select>
 </select>
     </p>
 <p><label for="">eBook</label></p>
@@ -180,18 +173,10 @@
     <p>
         <p><label for="">Genre</label></p>
         <select name="genre" id="genre">
-			<option value="{{ genre }}" selected="selected">{{ genre }}</option>
-  <option value="Sci-Fi">Sci-Fi</option>
-  <option value="Fantasy">Fantasy</option>
-<option value="Classic">Classic</option>
-			<option value="Reference">Reference</option>
-			<option value="Young Adult">Young Adult</option>
-			<option value="Historical Fiction">Historical Fiction</option>
-			<option value="Mystery">Mystery</option>
-			<option value="Anthology">Anthology</option>
-			<option value="Horror">Horror</option>
-			<option value="Romance">Romance</option>
-			<option value="Animal Fiction">Animal Fiction</option>
+			<option value="Uncategorized" selected="selected">Uncategorized</option>
+			{% for genre in config.genres.split(",") %}
+				<option value="{{ genre }}">{{ genre }}</option>
+			{% endfor %}
 </select>
     </p>
         <p><label for="">eBook</label></p>

--- a/templates/updateBook.html
+++ b/templates/updateBook.html
@@ -71,17 +71,9 @@
         <p><label for="">Genre</label></p>
                 <select name="genre" id="genre">
 					<option value="{{ book.genre }}" selected>{{ book.genre }}</option>
-  <option value="Sci-Fi">Sci-Fi</option>
-  <option value="Fantasy">Fantasy</option>
-<option value="Classic">Classic</option>
-			<option value="Reference">Reference</option>
-			<option value="Young Adult">Young Adult</option>
-			<option value="Historical Fiction">Historical Fiction</option>
-			<option value="Mystery">Mystery</option>
-			<option value="Anthology">Anthology</option>
-			<option value="Horror">Horror</option>
-			<option value="Romance">Romance</option>
-					<option value="Animal Fiction">Animal Fiction</option>
+					{% for genre in config.genres.split(",") %}
+						<option value="{{ genre }}">{{ genre }}</option>
+					{% endfor %}
 </select>
     </p>
 

--- a/ubiblio/crud.py
+++ b/ubiblio/crud.py
@@ -296,9 +296,9 @@ def initConfig(db: Session):
         config = db.query(models.config).first()
         if not config:    
             conn = sqlite3.connect(DB_LOCATION)
-            initData =["1.0.0",False,"",""]
-            cursor = conn.execute('create table if not exists Config (id INTEGER PRIMARY KEY, version VARCHAR, coverImages BOOLEAN, customFieldName1 VARCHAR, customFieldName2 VARCHAR);')
-            cursor = conn.execute('INSERT INTO config (version, coverImages, customFieldName1, customFieldName2) VALUES (?, ?, ?, ?);', initData)
+            initData =["1.0.1",False,"","",",".join(schemas.DEFAULT_GENRES)]
+            cursor = conn.execute('create table if not exists Config (id INTEGER PRIMARY KEY, version VARCHAR, coverImages BOOLEAN, customFieldName1 VARCHAR, customFieldName2 VARCHAR, genres VARCHAR);')
+            cursor = conn.execute('INSERT INTO config (version, coverImages, customFieldName1, customFieldName2, genres) VALUES (?, ?, ?, ?, ?);', initData)
             conn.commit()
             conn.close()
             return

--- a/ubiblio/main.py
+++ b/ubiblio/main.py
@@ -831,7 +831,7 @@ async def updateConfig(request: Request, user: schemas.User = Depends(get_curren
             await form.load_data()
             if await form.is_valid():
                     db = SessionLocal()
-                    config = schemas.config(id = 1, version=form.version, coverImages=form.coverImages, customFieldName1=form.customFieldName1, customFieldName2=form.customFieldName2)
+                    config = schemas.config(id = 1, version=form.version, coverImages=form.coverImages, customFieldName1=form.customFieldName1, customFieldName2=form.customFieldName2, genres=form.genres)
                     crud.updateConfig(db, config)
                     config = crud.getConfig(db)
                     db.close()
@@ -1104,6 +1104,7 @@ class configForm:
         self.coverImages: Optional[bool] = None
         self.customFieldName1: Optional[str] = None
         self.customFieldName2: Optional[str] = None
+        self.genres: str = ""
 
     async def load_data(self):
         form = await self.request.form()
@@ -1111,6 +1112,7 @@ class configForm:
         self.coverImages = form.get("coverImages")
         self.customFieldName1 = form.get("customFieldName1")
         self.customFieldName2 = form.get("customFieldName2")
+        self.genres = form.get("genres") or ",".join(schemas.DEFAULT_GENRES)
 
     async def is_valid(self):
         if not self.version:

--- a/ubiblio/models.py
+++ b/ubiblio/models.py
@@ -48,6 +48,7 @@ class config(Base):
     coverImages = Column(Boolean)
     customFieldName1 = Column(String, nullable=True)
     customFieldName2 = Column(String, nullable=True)
+    genres = Column(String)
 
 class ebook(Base):
     __tablename__ = "ebooks"

--- a/ubiblio/schemas.py
+++ b/ubiblio/schemas.py
@@ -2,6 +2,10 @@ from pydantic import BaseModel, Field
 from datetime import datetime
 from typing import Optional
 
+DEFAULT_GENRES=[
+    "Sci-Fi", "Fantasy", "Classic", "Reference", "Young Adult", "Historical Fiction", "Mystery", "Anthology", "Horror", "Romance", "Animal Fiction"
+]
+
 class UserBase(BaseModel):
     username: str
     isAdmin: bool = Field(default=False)
@@ -84,6 +88,7 @@ class config(BaseModel):
     coverImages: bool = Field(default=False)
     customFieldName1: Optional[str] = Field(default=None)
     customFieldName2: Optional[str] = Field(default=None)
+    genres: str = Field(default=",".join(DEFAULT_GENRES))
     class Config:
         orm_mode = True  
 


### PR DESCRIPTION
The default genres are the same as before.

I'm not really sure how you would like to handle the database migration since this PR adds a new `genres` field to the `Config` database column, I'd be thankful for some input on that.