### PR TITLE
Feature: Scan ISBN to populate field

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,21 @@
+version: '3.8'
+
+services:
+  ubiblio:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      - DEV=true
+      - DB_LOCATION=./config/sql_app.db
+      - SECRET_KEY_FILE=/app/config/secret_key.txt
+      - ADMIN_USERNAME=${ADMIN_USERNAME}
+      - ADMIN_PASSWORD=${ADMIN_PASSWORD}
+      - CREATE_ADMIN_USER=True
+    volumes:
+      - ./:/app:cached
+    ports:
+      - "8000:8000"
+    command: ["./entrypoint.sh"]
+    # Use a bind mount so edits you make on the host are visible inside the container.
+    # The image will run uvicorn with --reload (because DEV=true) and pick up changes.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+# Development mode: if DEV=true, run uvicorn with reload and do not change ownership
+if [ "$DEV" = "true" ] || [ "$DEV" = "1" ]; then
+  exec uvicorn ubiblio.main:app --host 0.0.0.0 --port 8000 --reload --forwarded-allow-ips '*' --proxy-headers
+fi
+
+# Production/default behaviour: create user if PUID/PGID are provided and run as that user
 if [ -z "$PUID" ] || [ -z "$PGID" ]; then
   exec uvicorn ubiblio.main:app --host 0.0.0.0 --port 8000 --forwarded-allow-ips '*' --proxy-headers
 else

--- a/templates/booksearch.html
+++ b/templates/booksearch.html
@@ -24,7 +24,8 @@
   <input style ="float:left;" type="submit" value="Search">										
 </form>
 <a style ='text-decoration:none !important; border:none;margin-left:25px;' href="/add_book"><button style="margin-bottom:25px;">Add New</button></a>
-		
+<a style ='text-decoration:none !important; border:none;margin-left:25px;' href="/scan_isbn"><button style="margin-bottom:25px;">Scan ISBN</button></a>
+
 <h2 style="margin-top:25px; margin-bottom:15px;">Book List</h2>
 
 <div class="container">  

--- a/templates/newBook.html
+++ b/templates/newBook.html
@@ -12,6 +12,7 @@
 <h1>Add a New Book</h1>
 {% if addISBN %} 
 <a style ="text-decoration:none !important; border:none;" onclick = "document.bookExistsAdder.action = '/addanotherisbn';document.bookExistsAdder.submit();"><button>Approve & Add Another</button></a>
+<a style ="text-decoration:none !important; border:none;" onclick = "document.bookExistsAdder.action = '/scananotherisbn';document.bookExistsAdder.submit();"><button>Approve & Scan Another</button></a>
 {% endif %}
 {% if book %} 									
 <form id ="bookExistsAdder" name = "bookExistsAdder" action="/add_book" method="post">

--- a/templates/scanIsbn.html
+++ b/templates/scanIsbn.html
@@ -1,0 +1,187 @@
+{% extends "base.html" %}
+{% block main %}
+<!-- Banner -->
+<!-- Two -->
+<section id="two">
+  <div class="inner" style="padding: 20px 0 1em 0">
+    {% for error in errors %}
+    <p style="color: red">{{ error }}</p>
+    {% endfor %}
+    <h1>Scan ISBN</h1>
+
+    <!-- Scanner UI -->
+    <div id="scannerControls">
+      <div style="margin-bottom: 10px">
+        <label for="cameraSelect">Camera: </label>
+        <select id="cameraSelect" style="padding: 5px">
+          <option value="">Select a camera...</option>
+        </select>
+      </div>
+      <button id="startScanBtn" type="button">Start Camera Scan</button>
+      <button id="stopScanBtn" type="button" style="display:none">Stop Scan</button>
+      <p id="scanMsg" style="color: #555"></p>
+      <div id="scannerContainer" style="margin-top:8px; position:relative">
+        <div id="interactive" class="viewport" style="width:100%;max-width:420px;display:none"></div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<script src="https://cdn.jsdelivr.net/npm/@ericblade/quagga2/dist/quagga.min.js"></script>
+
+<script>
+  function isbn() {
+    var isbnLink = document.getElementsByName("isbnLink")[0].value;
+    if (isbnLink) window.location.href = "/isbn/" + encodeURIComponent(isbnLink);
+  }
+
+  // Quagga camera scanner implementation
+  const startBtn = document.getElementById('startScanBtn');
+  const stopBtn = document.getElementById('stopScanBtn');
+  const scanMsg = document.getElementById('scanMsg');
+  const interactive = document.getElementById('interactive');
+  const cameraSelect = document.getElementById('cameraSelect');
+  
+  let selectedDeviceId = null;
+  let isScanning = false;
+
+  // Populate camera list
+  async function populateCameraList() {
+    try {
+      // Request camera permission first
+      const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+      stream.getTracks().forEach(track => track.stop());
+      
+      // Now enumerate devices
+      const devices = await navigator.mediaDevices.enumerateDevices();
+      const videoDevices = devices.filter(device => device.kind === 'videoinput');
+      
+      cameraSelect.innerHTML = '<option value="">Select a camera...</option>';
+      videoDevices.forEach((device, index) => {
+        const option = document.createElement('option');
+        option.value = device.deviceId;
+        option.text = device.label || `Camera ${index + 1}`;
+        cameraSelect.appendChild(option);
+      });
+      
+      // Auto-select the first camera if available
+      if (videoDevices.length > 0) {
+        cameraSelect.value = videoDevices[0].deviceId;
+        selectedDeviceId = videoDevices[0].deviceId;
+        // Might as well start scanning right away
+        startScanner();
+      }
+    } catch (err) {
+      console.error('Error enumerating devices:', err);
+      scanMsg.textContent = 'Error accessing cameras: ' + err.message;
+    }
+  }
+
+  // Camera selection change
+  cameraSelect.addEventListener('change', async function() {
+    selectedDeviceId = this.value;
+    
+    // If already scanning, restart with new camera
+    if (isScanning) {
+      stopScanner();
+      // Small delay before restarting
+      setTimeout(() => startScanner(), 300);
+    }
+  });
+
+  startBtn.addEventListener('click', function() {
+    startScanner();
+  });
+
+  stopBtn.addEventListener('click', function() {
+    stopScanner();
+  });
+
+  function startScanner() {
+    if (!selectedDeviceId) {
+      scanMsg.textContent = 'Please select a camera first';
+      return;
+    }
+    
+    scanMsg.textContent = 'Initializing camera...';
+    interactive.style.display = 'block';
+    startBtn.style.display = 'none';
+    stopBtn.style.display = 'inline-block';
+    isScanning = true;
+
+    const config = {
+      inputStream: {
+        name: "Live",
+        type: "LiveStream",
+        target: document.querySelector('#interactive'),
+        constraints: {
+          deviceId: selectedDeviceId,
+          facingMode: "environment"
+        }
+      },
+      decoder: {
+        readers: [
+          "ean_reader", // EAN-13 (most common for books)
+        ]
+      },
+      locate: true,
+      numOfWorkers: navigator.hardwareConcurrency || 4,
+      frequency: 10
+    };
+
+    Quagga.init(config, function(err) {
+      if (err) {
+        console.error(err);
+        scanMsg.textContent = 'Error: ' + err.message;
+        stopScanner();
+        return;
+      }
+      scanMsg.textContent = 'Camera ready. Point at barcode...';
+      Quagga.start();
+    });
+
+    // Handle detected barcodes
+    Quagga.onDetected(function(result) {
+      const code = result.codeResult.code;
+      console.log("Barcode detected:", code);
+      
+      // Navigate to ISBN page
+      stopScanner();
+      window.location.href = "/isbn/" + encodeURIComponent(code);
+    });
+  }
+
+  function stopScanner() {
+    Quagga.stop();
+    interactive.style.display = 'none';
+    startBtn.style.display = 'inline-block';
+    stopBtn.style.display = 'none';
+    scanMsg.textContent = '';
+    isScanning = false;
+  }
+
+  // Initialize camera list on page load
+  populateCameraList();
+</script>
+
+<style>
+  #interactive.viewport {
+    position: relative;
+  }
+  #interactive.viewport canvas,
+  #interactive.viewport video {
+    width: 100%;
+    height: auto;
+  }
+  #interactive.viewport canvas.drawingBuffer {
+    position: absolute;
+    top: 0;
+    left: 0;
+  }
+  
+  #cameraSelect {
+    min-width: 200px;
+    max-width: 100%;
+  }
+</style>
+{% endblock %}

--- a/ubiblio/main.py
+++ b/ubiblio/main.py
@@ -406,6 +406,25 @@ def update_cust_form(bookId, request: Request, user: schemas.User = Depends(get_
         print(e)
         return "An error has occured."
 
+@app.get("/scan_isbn", dependencies=[get_rate_limiter(times=3, seconds=2)], response_class=HTMLResponse)
+def scan_book_form(request: Request, user: schemas.User = Depends(get_current_user_from_token)):
+    try:
+        if user.isAdmin:
+            db = SessionLocal()
+            config = crud.getConfig(db)
+            db.close()
+            context = {
+            "config": config,
+            "user": user,
+            "request": request,
+            }
+            return templates.TemplateResponse("scanIsbn.html", context)
+        if not user.isAdmin:
+            return "You are not authorized to add books. Only an admin can do this."
+    except Exception as e:
+        print(e)
+        return "An error has occured."
+
 # --------------------------------------------------------------------------
 # Search
 # --------------------------------------------------------------------------
@@ -532,6 +551,25 @@ async def addAnotherIsbn(request: Request, user: schemas.User = Depends(get_curr
     }
         return templates.TemplateResponse("addisbn.html", context)
     if not user.isAdmin == True:
+        return "You are not authorized to add books. Only an admin can do this."
+    
+@app.post("/scananotherisbn", dependencies=[get_rate_limiter(times=2, seconds=2)], response_class=HTMLResponse)
+async def scanAnotherIsbn(request: Request, user: schemas.User = Depends(get_current_user_from_token)):
+    if user.isAdmin:
+        #Add book
+        form = bookForm(request)
+        await form.load_data()
+        if await form.is_valid():
+            db = SessionLocal()
+            newBook = schemas.BookCreate(title=form.title, author=form.author, summary=form.summary, genre=form.genre, library=form.library, shelf=form.shelf, collection=form.collection, notes=form.notes, ISBN = form.ISBN, owned = form.owned, ebook = form.ebook, customField1=form.customField1, customField2=form.customField2, withdrawn=form.withdrawn)
+            crud.createBook(db, newBook)
+            db.close()
+            context = {
+            "user": user,
+        "request": request
+    }
+        return templates.TemplateResponse("scanIsbn.html", context)
+    if not user.isAdmin:
         return "You are not authorized to add books. Only an admin can do this."
 # --------------------------------------------------------------------------
 # Reading Lists


### PR DESCRIPTION
Hey!

This PR adds the ability to scan book ISBNs using the device camera. Users can now select their camera, scan a book, validate it, and scan another one in a continuous workflow.

## What Changed

**Frontend:**
- New `scanIsbn.html` template with Quagga2 integration
- Camera selection dropdown that auto-detects available cameras
- Small modifications to existing pages for navigation

**Backend:**
- `GET /scan_isbn` - Displays the scanner interface
- `POST /scananotherisbn` - Saves book and returns to scanner

**Tech stack:**
- Uses Quagga2 library for EAN-13 barcode detection (loaded via CDN)

## Testing

- ✅ Tested on mobile phone (Android)
- ✅ Camera selection works with multiple cameras
- ✅ Barcode detection seems reliable with good lighting
- ⚠️ Requires HTTPS context for camera access on mobile (I had to repurpose my existing nginx install ahah)

## Extra

I've added Docker Compose and slightly changed the `entrypoint.sh`. We can leave it out of the PR if you want - it's just somewhat more practical because you can run without rebuilding.

Please don't hesitate to ask if you have any questions! ( (I'm trying to get AI to help me generate good PR. Is it too much? I removed a lot of the fluff already, but it is hard to draw a clear line for PR)

Closes #26 
