### PR TITLE
Remove googleapis.com

### DIFF
--- a/templates/FR/base.html
+++ b/templates/FR/base.html
@@ -6,8 +6,7 @@
 -->
 <html>
 	<head>
-	<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
-
+		<script src="{{ url_for('static', path='assets/js/jquery.min.js')}}"></script>
 		<title>uBiblio</title>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />

--- a/templates/base.html
+++ b/templates/base.html
@@ -6,8 +6,7 @@
 -->
 <html>
 	<head>
-	<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
-
+		<script src="{{ url_for('static', path='assets/js/jquery.min.js') }}"></script>
 		<title>uBiblio</title>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />


### PR DESCRIPTION
This removes the javascript link for jquery.min.js by using locally-supplied version instead. This will remove one avenue for Google to spy on users of this software.