### PR TITLE
Allow docker to cache pip installations during build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,11 +11,13 @@ RUN mkdir /app
 
 WORKDIR /app
 
-COPY . .
+COPY ./requirements.txt ./
 
 RUN \
   cd /app && \
   pip install -r requirements.txt --break-system-packages
+
+COPY . .
 
 RUN chmod +x entrypoint.sh
 


### PR DESCRIPTION
This modifies the Dockerfile so that pip dependencies are only installed if the requirements.txt is changed. This will reduce the time it takes to rebuild docker images and also reduce the network load on the servers providing pip packages.