### PR TITLE
[Issue #55] Upgrade FastAPI and Pydanti

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-fastapi==0.115.4
+fastapi==0.135.3
 fastapi_limiter==0.1.6
 passlib==1.7.4
-pydantic==1.10.2
+pydantic==2.12.5
 PyMySQL==1.1.1
 python_jose==3.3.0
 redis==4.5.5
@@ -12,6 +12,6 @@ gunicorn==23.0.0
 jinja2==3.1.2
 python-multipart==0.0.5
 aiofiles==24.1.0
-pillow==9.0.1
+pillow==12.2.0
 uuid==1.30
 requests==2.32.2

--- a/ubiblio/crud.py
+++ b/ubiblio/crud.py
@@ -45,7 +45,7 @@ def isAdmin(db: Session, username: str):
 
 def createBook(db: Session, book: schemas.Book):
     try:
-        book = models.Book(** book.dict())
+        book = models.Book(** book.model_dump())
         db.add(book)
         db.commit()
         db.refresh(book)
@@ -78,7 +78,7 @@ def updateBook(db: Session, book: schemas.Book):
     try:
         item = db.get(models.Book, book.id) 
         if item:
-            book = models.Book(** book.dict())
+            book = models.Book(** book.model_dump())
             db.merge(book)
             db.commit()   
         if not item:
@@ -179,7 +179,7 @@ def getGenres(db: Session):
     
 def readBook(db: Session, readingListItem: schemas.readingListItemCreate):
     try:
-        readingListItem = models.readingListItems(** readingListItem.dict())
+        readingListItem = models.readingListItems(** readingListItem.model_dump())
         db.add(readingListItem)
         db.commit()
         db.refresh(readingListItem)
@@ -247,7 +247,7 @@ def bookReturn(db: Session, book: schemas.Book):
     try:  
         item = db.get(models.Book, book.id)  
         if item:
-            book = models.Book(** book.dict())
+            book = models.Book(** book.model_dump())
             db.merge(book)
             db.commit()   
         if not item:
@@ -261,7 +261,7 @@ def bookWithdraw(db: Session, book: schemas.Book):
     try:
         item = db.get(models.Book, book.id)  
         if item:
-            book = models.Book(** book.dict())
+            book = models.Book(** book.model_dump())
             db.merge(book)
             db.commit()   
         if not item:
@@ -366,7 +366,7 @@ def getVersion():
 def updateConfig(db: Session, config: schemas.config):
     try:
         config_exists = db.query(models.config).first()
-        config = models.config(** config.dict())
+        config = models.config(** config.model_dump())
         if config_exists:
             db.merge(config)
             db.commit()
@@ -416,7 +416,7 @@ def getImagesByFilename(db: Session, filename: str):
 
 def addImage(db: Session, image: schemas.bookImageBase):
     try:
-        image = models.bookImage(** image.dict())
+        image = models.bookImage(** image.model_dump())
         db.add(image)
         db.commit()
         db.refresh(image)
@@ -440,7 +440,7 @@ def deleteImage(db: Session, imageId: int):
 
 def addEbook(db: Session, ebook: schemas.ebookBase):
     try:
-        ebook = models.ebook(** ebook.dict())
+        ebook = models.ebook(** ebook.model_dump())
         db.add(ebook)
         db.commit()
         db.refresh(ebook)
@@ -578,7 +578,7 @@ def deleteVkey(db: Session, keyId: int):
         
 def addVkey(db: Session, newKey: schemas.vkeyBase):
     try:
-        vkey = models.vkey(** newKey.dict())
+        vkey = models.vkey(** newKey.model_dump())
         db.add(vkey)
         db.commit()
         db.refresh(vkey)

--- a/ubiblio/main.py
+++ b/ubiblio/main.py
@@ -70,7 +70,7 @@ app.add_middleware(
     CORSMiddleware,
     allow_origins=['*'],
     allow_credentials=False,
-    allow_methods=['POST'],
+    allow_methods=['*'],
     allow_headers=['*']
 )
 

--- a/ubiblio/main.py
+++ b/ubiblio/main.py
@@ -65,12 +65,11 @@ models.Base.metadata.create_all(bind=engine)
 app = FastAPI()
 favicon_path = 'favicon.ico'
 
-
 app.add_middleware(
     CORSMiddleware,
     allow_origins=['*'],
     allow_credentials=False,
-    allow_methods=['*'],
+    allow_methods=['POST'],
     allow_headers=['*']
 )
 
@@ -247,8 +246,8 @@ async def login_post(request: Request):
         except HTTPException:
             form.__dict__.update(msg="")
             form.__dict__.get("errors").append("Incorrect Email or Password")
-            return templates.TemplateResponse("login.html", form.__dict__)
-    return templates.TemplateResponse("login.html", form.__dict__)
+            return templates.TemplateResponse(request, "login.html", form.__dict__)
+    return templates.TemplateResponse(request, "login.html", form.__dict__)
 
 
 @app.get("/auth/logout", response_class=HTMLResponse)
@@ -271,7 +270,7 @@ def index(request: Request):
         context = {
         "request": request
     }
-        return templates.TemplateResponse("login.html", context)
+        return templates.TemplateResponse(request, "login.html", context)
     if user:
         databaseNotFirstVersion = crud.checkDB()
         if databaseNotFirstVersion == True:
@@ -302,7 +301,7 @@ def add_book_form(request: Request, user: schemas.User = Depends(get_current_use
             "user": user,
             "request": request,
             }
-            return templates.TemplateResponse("newBook.html", context)
+            return templates.TemplateResponse(request, "newBook.html", context)
         if not user.isAdmin == True:
             return "You are not authorized to add books. Only an admin can do this."
     except Exception as e:
@@ -358,10 +357,10 @@ async def bookDetails(bookId, request: Request, user: schemas.User = Depends(get
             ebookFiles = crud.getEbookFiles(db, bookId)
             context["ebookFiles"] = ebookFiles  
             db.close()
-            return templates.TemplateResponse("ebookDetails.html", context)
+            return templates.TemplateResponse(request, "ebookDetails.html", context)
         else:
             db.close()
-            return templates.TemplateResponse("bookDetails.html", context)
+            return templates.TemplateResponse(request, "bookDetails.html", context)
     if not user:
         return "You are not logged in. Login to view books."
 
@@ -405,7 +404,7 @@ def update_cust_form(bookId, request: Request, user: schemas.User = Depends(get_
             "book": book,
             "request": request
             }
-            return templates.TemplateResponse("updateBook.html", context)
+            return templates.TemplateResponse(request, "updateBook.html", context)
         if not user.isAdmin == True:
             return "You are not authorized to update books. Only an admin can do this."
     except Exception as e:
@@ -424,7 +423,7 @@ def scan_book_form(request: Request, user: schemas.User = Depends(get_current_us
             "user": user,
             "request": request,
             }
-            return templates.TemplateResponse("scanIsbn.html", context)
+            return templates.TemplateResponse(request, "scanIsbn.html", context)
         if not user.isAdmin:
             return "You are not authorized to add books. Only an admin can do this."
     except Exception as e:
@@ -442,7 +441,7 @@ def searchbookget(request: Request, user: schemas.User = Depends(get_current_use
         "user": user,
         "data": data
     }
-    return templates.TemplateResponse("booksearch.html", context)
+    return templates.TemplateResponse(request, "booksearch.html", context)
 
 @app.post("/searchbooks", dependencies=[get_rate_limiter(times=4, seconds=1)], response_class=HTMLResponse)
 def searchBooks(request: Request, user: schemas.User = Depends(get_current_user_from_token), title: str = "%", author: str= "%",skip: int = "%",onlyEbooks: bool = "%", noEbooks:  bool = "%"):
@@ -505,7 +504,8 @@ def goobMeta(isbn,key):
             book["Summary"] = ""
         return book, 200
     else:
-        return {},response.status_code
+        return {}, response.status_code
+
 def openLibMeta(isbn):
     url = "https://openlibrary.org/isbn/" + str(isbn) + ".json"
     headers = {
@@ -620,7 +620,7 @@ def new_isbn(isbn, method, response: Response, request: Request, user: schemas.U
         "book": book,
         "request": request
     }
-            return templates.TemplateResponse("newBook.html", context)
+            return templates.TemplateResponse(request, "newBook.html", context)
         if not user.isAdmin == True:
             return "You are not authorized to update books. Only an admin can do this."
     except Exception as e:
@@ -632,9 +632,9 @@ def new_isbn(isbn, method, response: Response, request: Request, user: schemas.U
     }
     #Return user to the page they were already on if no book found with this ISBN -- they can try again if they wish, or move to the next book.
         if method == "scan":
-            return templates.TemplateResponse("scanIsbn.html", context)
+            return templates.TemplateResponse(request, "scanIsbn.html", context)
         else:
-            return templates.TemplateResponse("addisbn.html", context)
+            return templates.TemplateResponse(request, "addisbn.html", context)
 
 @app.get("/addisbn", dependencies=[get_rate_limiter(times=2, seconds=1)], response_class=HTMLResponse)
 async def addIsbn(request: Request, user: schemas.User = Depends(get_current_user_from_token)):
@@ -643,7 +643,7 @@ async def addIsbn(request: Request, user: schemas.User = Depends(get_current_use
         "user": user,
         "request": request
     }
-        return templates.TemplateResponse("addisbn.html", context)
+        return templates.TemplateResponse(request, "addisbn.html", context)
     if not user.isAdmin == True:
         return "You are not authorized to add books. Only an admin can do this."
 
@@ -662,7 +662,7 @@ async def addAnotherIsbn(request: Request, user: schemas.User = Depends(get_curr
             "user": user,
         "request": request
     }
-        return templates.TemplateResponse("addisbn.html", context)
+        return templates.TemplateResponse(request, "addisbn.html", context)
     if not user.isAdmin == True:
         return "You are not authorized to add books. Only an admin can do this."
     
@@ -681,7 +681,7 @@ async def scanAnotherIsbn(request: Request, user: schemas.User = Depends(get_cur
             "user": user,
         "request": request
     }
-        return templates.TemplateResponse("scanIsbn.html", context)
+        return templates.TemplateResponse(request, "scanIsbn.html", context)
     if not user.isAdmin:
         return "You are not authorized to add books. Only an admin can do this."
 # --------------------------------------------------------------------------
@@ -723,7 +723,7 @@ async def readList(request: Request, user: schemas.User = Depends(get_current_us
         "user": user,
         "request": request
     }
-        return templates.TemplateResponse("readinglist.html", context)
+        return templates.TemplateResponse(request, "readinglist.html", context)
     if not user:
         return "You are not logged in. Login to see your reading list."
 # --------------------------------------------------------------------------
@@ -769,7 +769,7 @@ async def wdList(request: Request, user: schemas.User = Depends(get_current_user
         "books": books,
         "request": request
     }
-        return templates.TemplateResponse("withdrawn.html", context)
+        return templates.TemplateResponse(request, "withdrawn.html", context)
     if not user:
         return "You are not logged in. Login to see withdrawn books."
 
@@ -787,7 +787,7 @@ async def updatePage(request: Request, user: schemas.User = Depends(get_current_
         "user": user,
         "request": request,
     }
-   return templates.TemplateResponse("updateAdvisory.html", context)
+   return templates.TemplateResponse(request, "updateAdvisory.html", context)
 
 @app.get("/dbUpdateVersion", dependencies=[get_rate_limiter(times=1, seconds=2)], response_class=HTMLResponse)
 async def updatePage(request: Request, user: schemas.User = Depends(get_current_user_from_token)):
@@ -795,7 +795,7 @@ async def updatePage(request: Request, user: schemas.User = Depends(get_current_
         "user": user,
         "request": request,
     }
-   return templates.TemplateResponse("updateVersion.html", context)
+   return templates.TemplateResponse(request, "updateVersion.html", context)
 
 #This is the function for updating the oldest version of the app only. DB versioning is implemented after. 
 @app.get("/updateDB", dependencies=[get_rate_limiter(times=1, seconds=10)], response_class=HTMLResponse)
@@ -894,7 +894,7 @@ async def backups(request: Request, user: schemas.User = Depends(get_current_use
         "bookExports":bookExports,
         "fileExports":fileExports,
     }
-        return templates.TemplateResponse("backups.html", context)
+        return templates.TemplateResponse(request, "backups.html", context)
     except:
            return "Only an admin can view database backups." 
 
@@ -1011,7 +1011,7 @@ async def config(request: Request, user: schemas.User = Depends(get_current_user
         "request": request,
         "config":config,
     }
-        return templates.TemplateResponse("config.html", context)
+        return templates.TemplateResponse(request, "config.html", context)
     except:
            return "Only an admin can edit the library configuration."    
    
@@ -1032,7 +1032,7 @@ async def updateConfig(request: Request, user: schemas.User = Depends(get_curren
                     "config": config,
                     "request": request,
                      }
-                    return templates.TemplateResponse("config.html", context)
+                    return templates.TemplateResponse(request, "config.html", context)
     except Exception as e:
         return "Only an admin can edit the library configuration."
                       
@@ -1051,7 +1051,7 @@ async def bookDetails(genre, request: Request, user: schemas.User = Depends(get_
         "books": books,
         "request": request
     }
-        return templates.TemplateResponse("booksByGenre.html", context)
+        return templates.TemplateResponse(request, "booksByGenre.html", context)
     if not user:
         return "You are not logged in. Login to view books."
 
@@ -1066,7 +1066,7 @@ async def bookGenres(request: Request, user: schemas.User = Depends(get_current_
         "genres": genres,
         "request": request
     }
-        return templates.TemplateResponse("genres.html", context)
+        return templates.TemplateResponse(request, "genres.html", context)
     if not user:
         return "You are not logged in. Login to view books."
 
@@ -1208,7 +1208,7 @@ async def wishlist(request: Request, user: schemas.User = Depends(get_current_us
         "books": books,
         "request": request
     }
-        return templates.TemplateResponse("wishlist.html", context)
+        return templates.TemplateResponse(request, "wishlist.html", context)
     if not user:
         return "You are not logged in. Login to view books."
 
@@ -1224,7 +1224,7 @@ async def userManagement(request: Request, user: schemas.User = Depends(get_curr
             "user": user,
         "request": request
     }
-            return templates.TemplateResponse("userManagement.html", context)
+            return templates.TemplateResponse(request, "userManagement.html", context)
     except:
            return "Only an admin can manage users."  
 
@@ -1277,7 +1277,7 @@ async def userManagement(request: Request, user: schemas.User = Depends(get_curr
             "user": user,
         "request": request
     }
-            return templates.TemplateResponse("userManagement.html", context)
+            return templates.TemplateResponse(request, "userManagement.html", context)
     except:
            return "Only an admin can manage users."
 
@@ -1308,7 +1308,7 @@ async def newUserGet(request: Request, user: schemas.User = Depends(get_current_
         "request": request,
         "user": user
     }
-        return templates.TemplateResponse("userLink.html", context)
+        return templates.TemplateResponse(request, "userLink.html", context)
     except:
            return "Only an admin can add users."  
     finally:
@@ -1324,7 +1324,7 @@ async def newUserPost(request: Request, accessCode: str):
         "accessCode": accessCode,
         "request": request
     }
-            return templates.TemplateResponse("createUser.html", context)
+            return templates.TemplateResponse(request, "createUser.html", context)
         else:
             return "Your access code is invalid or expired." 
     except:
@@ -1353,7 +1353,7 @@ async def createUserWithCode(request: Request):
             "request": request,
             "errors":errors
             }
-                return templates.TemplateResponse("login.html", context)
+                return templates.TemplateResponse(request, "login.html", context)
             else: 
                 raise Exception("Failed to create account.") 
         else:
@@ -1365,7 +1365,7 @@ async def createUserWithCode(request: Request):
             "request": request,
             "errors":errors
             }    
-        return templates.TemplateResponse("createUser.html", context)
+        return templates.TemplateResponse(request, "createUser.html", context)
     
     except Exception as e:
         errors = [e]
@@ -1374,7 +1374,7 @@ async def createUserWithCode(request: Request):
             "request": request,
             "errors":errors
             }    
-        return templates.TemplateResponse("createUser.html", context)
+        return templates.TemplateResponse(request, "createUser.html", context)
             
         
 # --------------------------------------------------------------------------
@@ -1413,7 +1413,7 @@ async def signUserSearch(request: Request, user: schemas.User = Depends(get_curr
         "request": request,
         "vkeys":vkeys
     }
-        return templates.TemplateResponse("fedsearch.html", context)
+        return templates.TemplateResponse(request, "fedsearch.html", context)
     except:
            return "FAIL"
 
@@ -1460,7 +1460,7 @@ async def getFedBookDetails(request: Request, bookId: int, vkeyId: int, user: sc
         "vkey": vkey,
         "bookId": bookId
     }
-        return templates.TemplateResponse("fedBookDetails.html", context)
+        return templates.TemplateResponse(request, "fedBookDetails.html", context)
     except:
            return "FAIL"
            
@@ -1500,7 +1500,7 @@ async def managekeys(request: Request, user: schemas.User = Depends(get_current_
             "user": user,
         "request": request
     }
-           return templates.TemplateResponse("vkeyManagement.html", context)
+           return templates.TemplateResponse(request, "vkeyManagement.html", context)
         else:
             return "Only an admin can manage verification keys."  
     except Exception as e:
@@ -1533,7 +1533,7 @@ async def managekeys(request: Request, user: schemas.User = Depends(get_current_
             "user": user,
         "request": request
     }
-           return templates.TemplateResponse("newVkey.html", context)
+           return templates.TemplateResponse(request, "newVkey.html", context)
         else:
             return "Only an admin can add new verification keys."  
     except Exception as e:
@@ -1631,7 +1631,7 @@ async def statsg(request: Request, user: schemas.User = Depends(get_current_user
             "user": user,
         "request": request
     }
-        return templates.TemplateResponse("stats.html", context)
+        return templates.TemplateResponse(request, "stats.html", context)
     except Exception as e:
             print(e)
             return "Fail"
@@ -1647,7 +1647,7 @@ def login_get(request: Request):
     context = {
         "request": request,
     }
-    return templates.TemplateResponse("login.html", context)
+    return templates.TemplateResponse(request, "login.html", context)
 
 
 # --------------------------------------------------------------------------

--- a/ubiblio/schemas.py
+++ b/ubiblio/schemas.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from datetime import datetime
 from typing import Optional
 
@@ -9,8 +9,7 @@ DEFAULT_GENRES=[
 class UserBase(BaseModel):
     username: str
     isAdmin: bool = Field(default=False)
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
     
 
 class User(UserBase):
@@ -25,92 +24,85 @@ class UserCreate(UserBase):
 
 class BookBase(BaseModel):
     title: str
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
 
 class Book(BookBase):
     id: int 
-    author: str = Field(default=None)
-    summary: str = Field(default=None)
-    genre: str = Field(default=None)
-    library: str = Field(default=None)
-    shelf: str = Field(default=None)
-    collection: str = Field(default=None)
-    ISBN: str = Field(default=None)
-    notes: str = Field(default=None)
+    author: Optional[str] = Field(default=None)
+    summary: Optional[str] = Field(default=None)
+    genre: Optional[str] = Field(default=None)
+    library: Optional[str] = Field(default=None)
+    shelf: Optional[str] = Field(default=None)
+    collection: Optional[str] = Field(default=None)
+    ISBN: Optional[str] = Field(default=None)
+    notes: Optional[str] = Field(default=None)
     owned: bool = Field(default=False)
     withdrawn: bool = Field(default=False)
-    withdrawnBy: Optional[str] = Field(default=False)
+    withdrawnBy: Optional[str] = Field(default=None)
     customField1: Optional[str] = Field(default=None)
     customField2: Optional[str] = Field(default=None)
     ebook: Optional[bool] = Field(default=False)
                 
 class BookCreate(BookBase):
-    author: str = Field(default=None)
-    summary: str = Field(default=None)
-    genre: str = Field(default=None)
-    library: str = Field(default=None)
-    shelf: str = Field(default=None)
-    collection: str = Field(default=None)
-    ISBN: str = Field(default=None)
-    notes: str = Field(default=None)
-    owned: bool = Field(default=None)
+    author: Optional[str] = Field(default=None)
+    summary: Optional[str] = Field(default=None)
+    genre: Optional[str] = Field(default=None)
+    library: Optional[str] = Field(default=None)
+    shelf: Optional[str] = Field(default=None)
+    collection: Optional[str] = Field(default=None)
+    ISBN: Optional[str] = Field(default=None)
+    notes: Optional[str] = Field(default=None)
+    owned: Optional[bool] = Field(default=None)
     withdrawn: bool = Field(default=False)    
-    withdrawnBy: Optional[str] = Field(default=False)
+    withdrawnBy: Optional[str] = Field(default=None)
     customField1: Optional[str] = Field(default=None)
     customField2: Optional[str] = Field(default=None)
     ebook: Optional[bool] = Field(default=False)
+
 class readingListItems(BaseModel):
     id: int
     book: int
     user_id: int 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
  
 class readingListItemCreate(BaseModel):
     book: int
     user_id: int
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
     
 class bookImageBase(BaseModel):  
     bookId: int
     filename: str
-    class Config:
-        orm_mode = True    
+    model_config = ConfigDict(from_attributes=True)
         
 class bookImage(bookImageBase):  
     id: int 
 
 class config(BaseModel):
     id: int 
-    version: str = Field(default=None)
+    version: Optional[str] = Field(default=None)
     coverImages: bool = Field(default=False)
     customFieldName1: Optional[str] = Field(default=None)
     customFieldName2: Optional[str] = Field(default=None)
     genres: str = Field(default=",".join(DEFAULT_GENRES))
-    class Config:
-        orm_mode = True  
+    model_config = ConfigDict(from_attributes=True)
 
 class userEmail(BaseModel):
     id: int
     email: str
     user_id: int 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
 
          
 class userEmailCreate(BaseModel):
     email: str
     user_id: int
-    class Config:
-        orm_mode = True    
+    model_config = ConfigDict(from_attributes=True)
 
 class ebookBase(BaseModel):  
     bookId: int
     filename: str
-    class Config:
-        orm_mode = True    
+    model_config = ConfigDict(from_attributes=True)
         
 class ebook(ebookBase):  
     id: int 
@@ -122,8 +114,7 @@ class linkBase(BaseModel):
 class link(linkBase):
     id: int  
     validity: datetime
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
 
 class vkeyBase(BaseModel):
     vkey: str
@@ -131,6 +122,4 @@ class vkeyBase(BaseModel):
     
 class vkey(vkeyBase):
     id: int  
-    class Config:
-        orm_mode = True
-
+    model_config = ConfigDict(from_attributes=True)


### PR DESCRIPTION
Changes:
    - Migrate to Pydantic v2 and update dependencies
    - Bump fastapi to 0.135.3, pydantic to 2.12.5, pillow to 12.2.0
    - Replace deprecated .dict() calls with .model_dump() throughout crud.py
    - Update TemplateResponse calls to use new request-first signature in main.py
    - Minor CORS and formatting fixes
Ref: https://github.com/seanboyce/ubiblio/pull/56#issuecomment-4230707960