### PR TITLE
 (Issue #59 and Issue #54) Allow scanning a book without Author

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ cover/
 local_settings.py
 db.sqlite3
 db.sqlite3-journal
+sql_app.db
 
 # Flask stuff:
 instance/
@@ -197,3 +198,5 @@ pyrightconfig.json
 
 config/
 secret_key.txt
+sign_key.txt
+verify_key.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ aiofiles==24.1.0
 pillow==12.2.0
 uuid==1.30
 requests==2.32.2
+responses==0.25.8

--- a/tests/routers/books/test_book_metadata_client.py
+++ b/tests/routers/books/test_book_metadata_client.py
@@ -2,6 +2,7 @@ from urllib.parse import urlencode
 
 from pytest import MonkeyPatch
 import responses
+import pytest
 
 from ubiblio.routers.books.book_metadata_client import BookMetadataClient
 
@@ -100,26 +101,22 @@ class TestBookMetadataClientOpenLibraryByIsbn:
 
         responses.add(
             responses.GET,
-            f"{BookMetadataClient.OPEN_LIBRARY_API}isbn/{isbn}.json",
+            f"{BookMetadataClient.OPEN_LIBRARY_API}/api/books?bibkeys=9780123456789&format=json&jscmd=details",
             json={
-                "title": "Test Title",
-                "authors": [
-                    {
-                        "key": "/authors/OL1607920A"
+                f"{isbn}": {
+                    "details": {
+                        "title": "Test Title",
+                        "authors": [
+                            {
+                                "key": "/authors/OL1607920A",
+                                "name": "A. Reader"
+                            }
+                        ],
+                        "description": {
+                            "value": "A fine book.",
+                        }
                     }
-                ],
-                "description": {
-                    "value": "A fine book.",
                 }
-            },
-            status=200,
-        )
-
-        responses.add(
-            responses.GET,
-            f"{BookMetadataClient.OPEN_LIBRARY_API}/authors/OL1607920A.json",
-            json={
-                "personal_name": "A. Reader",
             },
             status=200,
         )
@@ -135,17 +132,87 @@ class TestBookMetadataClientOpenLibraryByIsbn:
             "Author": "A. Reader",
             "Summary": "A fine book.",
         }
-        assert len(responses.calls) == 2
-        assert responses.calls[0].request.url == f"{BookMetadataClient.OPEN_LIBRARY_API}isbn/{isbn}.json"
-        assert responses.calls[1].request.url == f"{BookMetadataClient.OPEN_LIBRARY_API}/authors/OL1607920A.json"
+        assert len(responses.calls) == 1
+        assert responses.calls[0].request.url == f"{BookMetadataClient.OPEN_LIBRARY_API}/api/books?bibkeys={isbn}&format=json&jscmd=details"
 
     @responses.activate
-    def test_open_library_by_isbn_should_return_error_when_response_is_not_ok(self, monkeypatch: MonkeyPatch) -> None:
+    @pytest.mark.parametrize("arthur_value", [[], [{}], [{"key": "/authors/OL1607920A"}]])
+    def test_open_library_by_isbn_should_return_book_metadata_even_if_no_author_is_found(self, arthur_value: list[dict[str, str]]) -> None:
+        # Arrange
+        isbn = "9780123456789"
+
+        responses.add(
+            responses.GET,
+            f"{BookMetadataClient.OPEN_LIBRARY_API}/api/books?bibkeys={isbn}&format=json&jscmd=details",
+            json={
+                f"{isbn}": {
+                    "details": {
+                        "title": "Test Title",
+                        "authors": arthur_value,
+                        "description": {
+                            "value": "A fine book.",
+                        }
+                    }
+                }
+            },
+            status=200,
+        )
+
+        client = BookMetadataClient()
+
+        # Act
+        book, status = client.open_library_by_isbn(isbn)
+
+        # Assert
+        assert status == 200
+        assert book == {
+            "Title": "Test Title",
+            "Summary": "A fine book.",
+            "Author": "",
+        }
+        assert len(responses.calls) == 1
+        assert responses.calls[0].request.url == f"{BookMetadataClient.OPEN_LIBRARY_API}/api/books?bibkeys={isbn}&format=json&jscmd=details"
+
+    @responses.activate
+    def test_open_library_by_isbn_should_return_book_metadata_even_if_no_description_is_found(self, monkeypatch: MonkeyPatch) -> None:
+        # Arrange
+        isbn = "9780123456789"
+
+        responses.add(
+            responses.GET,
+            f"{BookMetadataClient.OPEN_LIBRARY_API}/api/books?bibkeys={isbn}&format=json&jscmd=details",
+            json={
+                f"{isbn}": {
+                    "details": {
+                        "title": "Test Title",
+                    }
+                }
+            },
+            status=200,
+        )
+
+        client = BookMetadataClient()
+
+        # Act
+        book, status = client.open_library_by_isbn(isbn)
+
+        # Assert
+        assert status == 200
+        assert book == {
+            "Title": "Test Title",
+            "Summary": "",
+            "Author": "",
+        }
+        assert len(responses.calls) == 1
+        assert responses.calls[0].request.url == f"{BookMetadataClient.OPEN_LIBRARY_API}/api/books?bibkeys={isbn}&format=json&jscmd=details"
+
+    @responses.activate
+    def test_open_library_by_isbn_should_return_error_when_response_is_not_ok(self) -> None:
         # Arrange
         isbn = "9780123456789"
         responses.add(
             responses.GET,
-            f"{BookMetadataClient.OPEN_LIBRARY_API}isbn/{isbn}.json",
+            f"{BookMetadataClient.OPEN_LIBRARY_API}/api/books?bibkeys={isbn}&format=json&jscmd=details",
             json={},
             status=404,
         )
@@ -158,44 +225,10 @@ class TestBookMetadataClientOpenLibraryByIsbn:
         assert status == 404
         assert book == {}
 
-    @responses.activate
-    def test_open_library_by_isbn_should_still_return_book_metadata_when_author_response_is_not_ok(self, monkeypatch: MonkeyPatch) -> None:
-        # Arrange
-        isbn = "9780123456789"
-        responses.add(
-            responses.GET,
-            f"{BookMetadataClient.OPEN_LIBRARY_API}isbn/{isbn}.json",
-            json={
-                "title": "Test Title",
-                "authors": [
-                    {
-                        "key": "/authors/OL1607920A"
-                    }
-                ],
-                "description": {
-                    "value": "A fine book.",
-                }
-            },
-            status=200,
-        )
-        responses.add(
-            responses.GET,
-            f"{BookMetadataClient.OPEN_LIBRARY_API}/authors/OL1607920A.json",
-            json={},
-            status=404,
-        )
-        client = BookMetadataClient()
-
-        # Act
-        book, status = client.open_library_by_isbn(isbn)
-        # Assert
-        assert status == 200
-        assert book == {"Summary": "A fine book.", "Title": "Test Title"}
-
 
 class TestBookMetadataClientOpenWikiByIsbn:
     @responses.activate
-    def test_open_wiki_by_isbn_should_return_book_metadata(self, monkeypatch: MonkeyPatch) -> None:
+    def test_open_wiki_by_isbn_should_return_book_metadata(self) -> None:
         # Arrange
         isbn = "9780123456789"
         responses.add(
@@ -228,9 +261,10 @@ class TestBookMetadataClientOpenWikiByIsbn:
             "Summary": "",
         }
         assert len(responses.calls) == 1
-    
+        assert responses.calls[0].request.url == f"{BookMetadataClient.OPEN_WIKI_API}isbn/{isbn}.json"
+
     @responses.activate
-    def test_open_wiki_by_isbn_should_return_error_when_response_is_not_ok(self, monkeypatch: MonkeyPatch) -> None:
+    def test_open_wiki_by_isbn_should_return_error_when_response_is_not_ok(self) -> None:
         # Arrange
         isbn = "9780123456789"
         responses.add(

--- a/tests/routers/books/test_book_metadata_client.py
+++ b/tests/routers/books/test_book_metadata_client.py
@@ -3,7 +3,7 @@ from urllib.parse import urlencode
 from pytest import MonkeyPatch
 import responses
 
-from ubiblio.routers.books.service import BookMetadataClient
+from ubiblio.routers.books.book_metadata_client import BookMetadataClient
 
 
 class TestBookMetadataClientGoogleBooksByIsbn:
@@ -13,8 +13,9 @@ class TestBookMetadataClientGoogleBooksByIsbn:
         isbn = "9780123456789"
         api_key = "test-api-key"
         monkeypatch.setattr(
-            "ubiblio.routers.books.service.GOOGLE_BOOKS_API_KEY", api_key)
-        query = urlencode({"q": f"isbn:{isbn}", "key": api_key})
+            "ubiblio.routers.books.book_metadata_client.GOOGLE_BOOKS_API_KEY", api_key
+        )
+        query = urlencode({"q": f"+isbn:{isbn}", "key": api_key})
         url = f"{BookMetadataClient.GOOGLE_BOOKS_API}?{query}"
         responses.add(
             responses.GET,
@@ -53,7 +54,8 @@ class TestBookMetadataClientGoogleBooksByIsbn:
         # Arrange
         isbn = "9780123456789"
         monkeypatch.setattr(
-            "ubiblio.routers.books.service.GOOGLE_BOOKS_API_KEY", None)
+            "ubiblio.routers.books.book_metadata_client.GOOGLE_BOOKS_API_KEY", None
+        )
         client = BookMetadataClient()
 
         # Act
@@ -69,8 +71,9 @@ class TestBookMetadataClientGoogleBooksByIsbn:
         isbn = "9780123456789"
         api_key = "test-api-key"
         monkeypatch.setattr(
-            "ubiblio.routers.books.service.GOOGLE_BOOKS_API_KEY", api_key)
-        query = urlencode({"q": f"isbn:{isbn}", "key": api_key})
+            "ubiblio.routers.books.book_metadata_client.GOOGLE_BOOKS_API_KEY", api_key
+        )
+        query = urlencode({"q": f"+isbn:{isbn}", "key": api_key})
         url = f"{BookMetadataClient.GOOGLE_BOOKS_API}?{query}"
         responses.add(
             responses.GET,
@@ -188,3 +191,58 @@ class TestBookMetadataClientOpenLibraryByIsbn:
         # Assert
         assert status == 200
         assert book == {"Summary": "A fine book.", "Title": "Test Title"}
+
+
+class TestBookMetadataClientOpenWikiByIsbn:
+    @responses.activate
+    def test_open_wiki_by_isbn_should_return_book_metadata(self, monkeypatch: MonkeyPatch) -> None:
+        # Arrange
+        isbn = "9780123456789"
+        responses.add(
+            responses.GET,
+            f"{BookMetadataClient.OPEN_WIKI_API}isbn/{isbn}.json",
+            json=[
+                {
+                    "key": "F5GJ7RVZ",
+                    "title": "Effective Book",
+                    "author": [
+                        [
+                            "First",
+                            "Last"
+                        ]
+                    ]
+                }
+            ]
+
+        )
+        client = BookMetadataClient()
+
+        # Act
+        book, status = client.open_wiki_by_isbn(isbn)
+
+        # Assert
+        assert status == 200
+        assert book == {
+            "Title": "Effective Book",
+            "Author": "First Last",
+            "Summary": "",
+        }
+        assert len(responses.calls) == 1
+    
+    @responses.activate
+    def test_open_wiki_by_isbn_should_return_error_when_response_is_not_ok(self, monkeypatch: MonkeyPatch) -> None:
+        # Arrange
+        isbn = "9780123456789"
+        responses.add(
+            responses.GET,
+            f"{BookMetadataClient.OPEN_WIKI_API}isbn/{isbn}.json",
+            json={},
+            status=404,
+        )
+        client = BookMetadataClient()
+
+        # Act
+        book, status = client.open_wiki_by_isbn(isbn)
+        # Assert
+        assert status == 404
+        assert book == {}

--- a/tests/routers/books/test_service.py
+++ b/tests/routers/books/test_service.py
@@ -1,0 +1,190 @@
+from urllib.parse import urlencode
+
+from pytest import MonkeyPatch
+import responses
+
+from ubiblio.routers.books.service import BookMetadataClient
+
+
+class TestBookMetadataClientGoogleBooksByIsbn:
+    @responses.activate
+    def test_google_books_by_isbn_should_return_book_metadata(self, monkeypatch: MonkeyPatch) -> None:
+        # Arrange
+        isbn = "9780123456789"
+        api_key = "test-api-key"
+        monkeypatch.setattr(
+            "ubiblio.routers.books.service.GOOGLE_BOOKS_API_KEY", api_key)
+        query = urlencode({"q": f"isbn:{isbn}", "key": api_key})
+        url = f"{BookMetadataClient.GOOGLE_BOOKS_API}?{query}"
+        responses.add(
+            responses.GET,
+            url,
+            json={
+                "items": [
+                    {
+                        "volumeInfo": {
+                            "title": "Test Title",
+                            "authors": ["A. Reader"],
+                            "description": "A fine book.",
+                        }
+                    }
+                ]
+            },
+            status=200,
+        )
+
+        client = BookMetadataClient()
+
+        # Act
+        book, status = client.google_books_by_isbn(isbn)
+
+        # Assert
+        assert status == 200
+        assert book == {
+            "Title": "Test Title",
+            "Author": "A. Reader",
+            "Summary": "A fine book."
+        }
+        assert len(responses.calls) == 1
+        assert responses.calls[0].request.url == url
+
+    @responses.activate
+    def test_google_books_by_isbn_should_return_error_when_api_key_is_missing(self, monkeypatch: MonkeyPatch) -> None:
+        # Arrange
+        isbn = "9780123456789"
+        monkeypatch.setattr(
+            "ubiblio.routers.books.service.GOOGLE_BOOKS_API_KEY", None)
+        client = BookMetadataClient()
+
+        # Act
+        book, status = client.google_books_by_isbn(isbn)
+
+        # Assert
+        assert status is None
+        assert book == {}
+
+    @responses.activate
+    def test_google_books_by_isbn_should_return_error_when_response_is_not_ok(self, monkeypatch: MonkeyPatch) -> None:
+        # Arrange
+        isbn = "9780123456789"
+        api_key = "test-api-key"
+        monkeypatch.setattr(
+            "ubiblio.routers.books.service.GOOGLE_BOOKS_API_KEY", api_key)
+        query = urlencode({"q": f"isbn:{isbn}", "key": api_key})
+        url = f"{BookMetadataClient.GOOGLE_BOOKS_API}?{query}"
+        responses.add(
+            responses.GET,
+            url,
+            json={"error": "notfound", "key": "/isbn/invalid"},
+            status=404,
+        )
+
+        client = BookMetadataClient()
+
+        # Act
+        book, status = client.google_books_by_isbn(isbn)
+
+        # Assert
+        assert status == 404
+        assert book == {}
+
+
+class TestBookMetadataClientOpenLibraryByIsbn:
+    @responses.activate
+    def test_open_library_by_isbn_should_return_book_metadata(self, monkeypatch: MonkeyPatch) -> None:
+        # Arrange
+        isbn = "9780123456789"
+
+        responses.add(
+            responses.GET,
+            f"{BookMetadataClient.OPEN_LIBRARY_API}isbn/{isbn}.json",
+            json={
+                "title": "Test Title",
+                "authors": [
+                    {
+                        "key": "/authors/OL1607920A"
+                    }
+                ],
+                "description": {
+                    "value": "A fine book.",
+                }
+            },
+            status=200,
+        )
+
+        responses.add(
+            responses.GET,
+            f"{BookMetadataClient.OPEN_LIBRARY_API}/authors/OL1607920A.json",
+            json={
+                "personal_name": "A. Reader",
+            },
+            status=200,
+        )
+
+        client = BookMetadataClient()
+
+        # Act
+        book, status = client.open_library_by_isbn(isbn)
+        # Assert
+        assert status == 200
+        assert book == {
+            "Title": "Test Title",
+            "Author": "A. Reader",
+            "Summary": "A fine book.",
+        }
+        assert len(responses.calls) == 2
+        assert responses.calls[0].request.url == f"{BookMetadataClient.OPEN_LIBRARY_API}isbn/{isbn}.json"
+        assert responses.calls[1].request.url == f"{BookMetadataClient.OPEN_LIBRARY_API}/authors/OL1607920A.json"
+
+    @responses.activate
+    def test_open_library_by_isbn_should_return_error_when_response_is_not_ok(self, monkeypatch: MonkeyPatch) -> None:
+        # Arrange
+        isbn = "9780123456789"
+        responses.add(
+            responses.GET,
+            f"{BookMetadataClient.OPEN_LIBRARY_API}isbn/{isbn}.json",
+            json={},
+            status=404,
+        )
+        client = BookMetadataClient()
+
+        # Act
+        book, status = client.open_library_by_isbn(isbn)
+
+        # Assert
+        assert status == 404
+        assert book == {}
+
+    @responses.activate
+    def test_open_library_by_isbn_should_still_return_book_metadata_when_author_response_is_not_ok(self, monkeypatch: MonkeyPatch) -> None:
+        # Arrange
+        isbn = "9780123456789"
+        responses.add(
+            responses.GET,
+            f"{BookMetadataClient.OPEN_LIBRARY_API}isbn/{isbn}.json",
+            json={
+                "title": "Test Title",
+                "authors": [
+                    {
+                        "key": "/authors/OL1607920A"
+                    }
+                ],
+                "description": {
+                    "value": "A fine book.",
+                }
+            },
+            status=200,
+        )
+        responses.add(
+            responses.GET,
+            f"{BookMetadataClient.OPEN_LIBRARY_API}/authors/OL1607920A.json",
+            json={},
+            status=404,
+        )
+        client = BookMetadataClient()
+
+        # Act
+        book, status = client.open_library_by_isbn(isbn)
+        # Assert
+        assert status == 200
+        assert book == {"Summary": "A fine book.", "Title": "Test Title"}

--- a/ubiblio/routers/books/__init__.py
+++ b/ubiblio/routers/books/__init__.py
@@ -1,0 +1,3 @@
+from .api import router
+
+__all__ = ["router"]

--- a/ubiblio/routers/books/api.py
+++ b/ubiblio/routers/books/api.py
@@ -1,101 +1,17 @@
 from fastapi import APIRouter, Depends, Request, Response, status
 from fastapi.responses import HTMLResponse, RedirectResponse
-from fastapi.encoders import jsonable_encoder
-import json
-import requests
-import time
 
-from .. import crud, schemas
-from ..database import SessionLocal
-from ..dependencies import (
-    get_rate_limiter, templates,
+from ... import crud, schemas
+from ...database import SessionLocal
+from ...dependencies import (
+    get_rate_limiter,
+    templates,
     get_current_user_from_token,
     bookForm,
 )
-from ..vars import GOOGLE_BOOKS_API_KEY
+from . import service
 
 router = APIRouter()
-
-
-# --------------------------------------------------------------------------
-# Book fetch functions (ISBN lookup helpers)
-# --------------------------------------------------------------------------
-def goobMeta(isbn, key):
-    url = "https://www.googleapis.com/books/v1/volumes?q=+isbn:" + str(isbn) + "&key=" + str(key)
-    response = requests.get(url)
-    if response.ok:
-        rawBook = json.loads(response.text)["items"][0]["volumeInfo"]
-        book = {}
-        book["Title"] = rawBook["title"]
-        book["Author"] = rawBook["authors"][0]
-        try:
-            book["Summary"] = rawBook["description"]
-        except:
-            book["Summary"] = ""
-        return book, 200
-    else:
-        return {}, response.status_code
-
-
-def openLibMeta(isbn):
-    url = "https://openlibrary.org/isbn/" + str(isbn) + ".json"
-    headers = {
-        "User-Agent": 'ubiblio_bot/1.0 (https://github.com/seanboyce/ubiblio;)',
-        "Accept-Encoding": 'gzip'
-    }
-    response = requests.get(url, headers=headers)
-    if response.ok:
-        rawBook = json.loads(response.text)
-        book = {}
-        book["Title"] = rawBook["title"]
-        authorURL = str(rawBook["authors"][0]["key"])
-        url = "https://openlibrary.org" + authorURL + ".json"
-        time.sleep(1)
-        response = requests.get(url)
-        if response.ok:
-            book["Author"] = json.loads(response.text)["personal_name"]
-        else:
-            print(response.status_code)
-        try:
-            book["Summary"] = rawBook["description"]["value"]
-        except:
-            book["Summary"] = ""
-        return book, 200
-    else:
-        return {}, response.status_code
-
-
-def openWikiMeta(isbn):
-    url = "https://en.wikipedia.org/api/rest_v1/data/citation/mediawiki/" + str(isbn)
-    headers = {
-        "User-Agent": 'ubiblio_bot/1.0 (https://github.com/seanboyce/ubiblio;)',
-        "Accept-Encoding": 'gzip'
-    }
-    response = requests.get(url, headers=headers)
-    if response.ok:
-        rawBook = json.loads(response.text)[0]
-        book = {}
-        book["Title"] = rawBook["title"]
-        rawAuthor = rawBook["author"][0]
-        author = ""
-        for i in rawAuthor:
-            author = author + i + " "
-        author = author.strip()
-        book["Author"] = author
-        book["Summary"] = ""
-        return book, 200
-    else:
-        return {}, response.status_code
-
-
-def goobTitle(title, key):
-    url = "https://www.googleapis.com/books/v1/volumes?q=+intitle:" + str(title) + "&key=" + str(key)
-    response = requests.get(url)
-    if response.ok:
-        rawBooks = json.loads(response.text)
-        return {}, 200
-    else:
-        return {}, response.status_code
 
 
 # --------------------------------------------------------------------------
@@ -114,7 +30,7 @@ def add_book_form(request: Request, user: schemas.User = Depends(get_current_use
                 "request": request,
             }
             return templates.TemplateResponse(request, "newBook.html", context)
-        if not user.isAdmin == True:
+        if not user.isAdmin != True:
             return "You are not authorized to add books. Only an admin can do this."
     except Exception as e:
         print(e)
@@ -130,10 +46,10 @@ async def add_book_post(request: Request, user: schemas.User = Depends(get_curre
     if await form.is_valid():
         try:
             db = SessionLocal()
-            newBook = schemas.BookCreate(title=form.title, author=form.author, summary=form.summary, genre=form.genre, library=form.library, shelf=form.shelf, collection=form.collection, notes=form.notes, ISBN=form.ISBN, owned=form.owned, ebook=form.ebook, customField1=form.customField1, customField2=form.customField2, withdrawn=form.withdrawn)
-            crud.createBook(db, newBook)
+            new_book = service.book_create_from_form(form)
+            crud.createBook(db, new_book)
             db.close()
-            return RedirectResponse(url='/searchbooks/', status_code=status.HTTP_303_SEE_OTHER)
+            return RedirectResponse(url="/searchbooks/", status_code=status.HTTP_303_SEE_OTHER)
         except Exception as e:
             print(e)
             return "Fail"
@@ -145,7 +61,7 @@ async def delete_book(bookId, request: Request, user: schemas.User = Depends(get
         db = SessionLocal()
         crud.deleteBook(db, bookId)
         db.close()
-        return RedirectResponse(url='/searchbooks/')
+        return RedirectResponse(url="/searchbooks/")
     if not user.isAdmin == True:
         return "You are not authorized to delete books. Only an admin can do this."
 
@@ -160,14 +76,14 @@ async def book_details(bookId, request: Request, user: schemas.User = Depends(ge
             "config": config,
             "book": book,
             "user": user,
-            "request": request
+            "request": request,
         }
         if config.coverImages:
             images = crud.getImages(db, bookId)
             context["images"] = images
         if book.ebook == True:
-            ebookFiles = crud.getEbookFiles(db, bookId)
-            context["ebookFiles"] = ebookFiles
+            ebook_files = crud.getEbookFiles(db, bookId)
+            context["ebookFiles"] = ebook_files
             db.close()
             return templates.TemplateResponse(request, "ebookDetails.html", context)
         else:
@@ -186,12 +102,11 @@ async def update_book(bookId, request: Request, user: schemas.User = Depends(get
     if await form.is_valid():
         try:
             db = SessionLocal()
-            config = crud.getConfig(db)
-            book = schemas.Book(id=bookId, title=form.title, author=form.author, summary=form.summary, genre=form.genre, library=form.library, shelf=form.shelf, collection=form.collection, notes=form.notes, ISBN=form.ISBN, owned=form.owned, ebook=form.ebook, customField1=form.customField1, customField2=form.customField2, withdrawn=form.withdrawn)
+            book = service.book_update_from_form(bookId, form)
             crud.updateBook(db, book)
             book = crud.getBookById(db, bookId)
             db.close()
-            return RedirectResponse(url='/bookDetails/' + bookId, status_code=status.HTTP_303_SEE_OTHER)
+            return RedirectResponse(url="/bookDetails/" + bookId, status_code=status.HTTP_303_SEE_OTHER)
         except Exception as e:
             print(e)
             return "Fail"
@@ -209,7 +124,7 @@ def update_book_form(bookId, request: Request, user: schemas.User = Depends(get_
                 "config": config,
                 "user": user,
                 "book": book,
-                "request": request
+                "request": request,
             }
             return templates.TemplateResponse(request, "updateBook.html", context)
         if not user.isAdmin == True:
@@ -248,56 +163,64 @@ def search_book_get(request: Request, user: schemas.User = Depends(get_current_u
     context = {
         "request": request,
         "user": user,
-        "data": data
+        "data": data,
     }
     return templates.TemplateResponse(request, "booksearch.html", context)
 
 
 @router.post("/searchbooks", dependencies=[get_rate_limiter(times=4, seconds=1)], response_class=HTMLResponse)
-def search_books(request: Request, user: schemas.User = Depends(get_current_user_from_token), title: str = "%", author: str = "%", skip: int = "%", onlyEbooks: bool = "%", noEbooks: bool = "%"):
+def search_books(
+    request: Request,
+    user: schemas.User = Depends(get_current_user_from_token),
+    title: str = "%",
+    author: str = "%",
+    skip: int = "%",
+    onlyEbooks: bool = "%",
+    noEbooks: bool = "%",
+):
+    db = SessionLocal()
     try:
-        db = SessionLocal()
-        books = crud.searchBooks(db, str(title), str(author), int(skip), bool(onlyEbooks), bool(noEbooks))
-        result = json.dumps(jsonable_encoder(books[0]))
-        data = {}
-        data['result'] = result
-        data['count'] = books[1]
+        return service.search_books_json(db, str(title), str(author), int(skip), bool(onlyEbooks), bool(noEbooks))
+    finally:
         db.close()
-        return json.dumps(jsonable_encoder(data))
-    except Exception as e:
-        print(e)
 
 
 @router.post("/searchBooksByAuthor", dependencies=[get_rate_limiter(times=4, seconds=1)], response_class=HTMLResponse)
-def search_book_author(request: Request, user: schemas.User = Depends(get_current_user_from_token), author: str = "%", skip: int = 0, onlyEbooks: bool = "%", noEbooks: bool = "%"):
+def search_book_author(
+    request: Request,
+    user: schemas.User = Depends(get_current_user_from_token),
+    author: str = "%",
+    skip: int = 0,
+    onlyEbooks: bool = "%",
+    noEbooks: bool = "%",
+):
+    db = SessionLocal()
     try:
-        db = SessionLocal()
-        books = jsonable_encoder(crud.searchBooksbyAuthor(db, str(author), int(skip), bool(onlyEbooks), bool(noEbooks)))
-        result = json.dumps(jsonable_encoder(books[0]))
-        data = {}
-        data['result'] = result
-        data['count'] = books[1]
+        out = service.search_books_by_author_json(db, str(author), int(skip), bool(onlyEbooks), bool(noEbooks))
+        if out is None:
+            return "An error has occured."
+        return out
+    finally:
         db.close()
-        return json.dumps(jsonable_encoder(data))
-    except Exception as e:
-        db.close()
-        return "An error has occured."
 
 
 @router.post("/searchBooksByTitle", dependencies=[get_rate_limiter(times=4, seconds=1)], response_class=HTMLResponse)
-def search_book_title(request: Request, user: schemas.User = Depends(get_current_user_from_token), title: str = "%", skip: int = 0, onlyEbooks: bool = "%", noEbooks: bool = "%"):
+def search_book_title(
+    request: Request,
+    user: schemas.User = Depends(get_current_user_from_token),
+    title: str = "%",
+    skip: int = 0,
+    onlyEbooks: bool = "%",
+    noEbooks: bool = "%",
+):
+    db = SessionLocal()
     try:
-        db = SessionLocal()
-        books = jsonable_encoder(crud.searchBooksbyTitle(db, str(title), int(skip), bool(onlyEbooks), bool(noEbooks)))
-        result = json.dumps(jsonable_encoder(books[0]))
-        data = {}
-        data['result'] = result
-        data['count'] = books[1]
+        out = service.search_books_by_title_json(db, str(title), int(skip), bool(onlyEbooks), bool(noEbooks))
+        if out is None:
+            return "An error has occured."
+        return out
+    finally:
         db.close()
-        return json.dumps(jsonable_encoder(data))
-    except Exception as e:
-        db.close()
-        return "An error has occured."
 
 
 # --------------------------------------------------------------------------
@@ -307,64 +230,28 @@ def search_book_title(request: Request, user: schemas.User = Depends(get_current
 def new_isbn(isbn, method, response: Response, request: Request, user: schemas.User = Depends(get_current_user_from_token)):
     try:
         if user.isAdmin == True:
-            book = {}
-            isbn = isbn.strip()
-            if len(GOOGLE_BOOKS_API_KEY) > 0:
-                try:
-                    book, response = goobMeta(isbn, GOOGLE_BOOKS_API_KEY)
-                    if response != 200:
-                        print("Google Books API failed with response: ")
-                        print(response)
-                except Exception as e:
-                    print("Google Books API failed with response: ")
-                    print(response)
-            else:
-                pass
-            try:
-                if len(book) == 0:
-                    book, response = openLibMeta(isbn)
-                    if response != 200:
-                        print("Open Library API failed with response: ")
-                        print(response)
-                else:
-                    pass
-            except Exception as e:
-                print("Open Library API failed with response: ")
-                print(e)
-            try:
-                if len(book) == 0:
-                    book, response = openWikiMeta(isbn)
-                    if response != 200:
-                        print("Wikipedia API failed with response: ")
-                        print(response)
-                else:
-                    pass
-            except Exception as e:
-                print("Wikipedia API failed with response: ")
-                print(e)
-            if len(book) == 0:
-                raise LookupError(f"Book with isbn {isbn} not found!")
-            addISBN = [0]
-            book = schemas.BookCreate(title=book["Title"], author=book["Author"], summary=book["Summary"], ISBN=isbn)
+            book = service.lookup_book_metadata_by_isbn(isbn)
+            add_isbn = [0]
+            book_schema = service.book_create_from_isbn_metadata(book, isbn.strip())
             db = SessionLocal()
             config = crud.getConfig(db)
             db.close()
             context = {
                 "config": config,
                 "user": user,
-                "addISBN": addISBN,
-                "book": book,
-                "request": request
+                "addISBN": add_isbn,
+                "book": book_schema,
+                "request": request,
             }
             return templates.TemplateResponse(request, "newBook.html", context)
         if not user.isAdmin == True:
             return "You are not authorized to update books. Only an admin can do this."
-    except Exception as e:
+    except Exception:
         errors = ["ISBN " + str(isbn) + " not found -- try another."]
         context = {
             "errors": errors,
             "user": user,
-            "request": request
+            "request": request,
         }
         if method == "scan":
             return templates.TemplateResponse(request, "scanIsbn.html", context)
@@ -377,7 +264,7 @@ async def add_isbn(request: Request, user: schemas.User = Depends(get_current_us
     if user.isAdmin == True:
         context = {
             "user": user,
-            "request": request
+            "request": request,
         }
         return templates.TemplateResponse(request, "addisbn.html", context)
     if not user.isAdmin == True:
@@ -391,12 +278,12 @@ async def add_another_isbn(request: Request, user: schemas.User = Depends(get_cu
         await form.load_data()
         if await form.is_valid():
             db = SessionLocal()
-            newBook = schemas.BookCreate(title=form.title, author=form.author, summary=form.summary, genre=form.genre, library=form.library, shelf=form.shelf, collection=form.collection, notes=form.notes, ISBN=form.ISBN, owned=form.owned, ebook=form.ebook, customField1=form.customField1, customField2=form.customField2, withdrawn=form.withdrawn)
-            crud.createBook(db, newBook)
+            new_book = service.book_create_from_form(form)
+            crud.createBook(db, new_book)
             db.close()
             context = {
                 "user": user,
-                "request": request
+                "request": request,
             }
         return templates.TemplateResponse(request, "addisbn.html", context)
     if not user.isAdmin == True:
@@ -410,12 +297,12 @@ async def scan_another_isbn(request: Request, user: schemas.User = Depends(get_c
         await form.load_data()
         if await form.is_valid():
             db = SessionLocal()
-            newBook = schemas.BookCreate(title=form.title, author=form.author, summary=form.summary, genre=form.genre, library=form.library, shelf=form.shelf, collection=form.collection, notes=form.notes, ISBN=form.ISBN, owned=form.owned, ebook=form.ebook, customField1=form.customField1, customField2=form.customField2, withdrawn=form.withdrawn)
-            crud.createBook(db, newBook)
+            new_book = service.book_create_from_form(form)
+            crud.createBook(db, new_book)
             db.close()
             context = {
                 "user": user,
-                "request": request
+                "request": request,
             }
         return templates.TemplateResponse(request, "scanIsbn.html", context)
     if not user.isAdmin:
@@ -434,7 +321,7 @@ async def books_by_genre(genre, request: Request, user: schemas.User = Depends(g
         context = {
             "user": user,
             "books": books,
-            "request": request
+            "request": request,
         }
         return templates.TemplateResponse(request, "booksByGenre.html", context)
     if not user:
@@ -450,7 +337,7 @@ async def book_genres(request: Request, user: schemas.User = Depends(get_current
         context = {
             "user": user,
             "genres": genres,
-            "request": request
+            "request": request,
         }
         return templates.TemplateResponse(request, "genres.html", context)
     if not user:

--- a/ubiblio/routers/books/book_metadata_client.py
+++ b/ubiblio/routers/books/book_metadata_client.py
@@ -8,7 +8,7 @@ from ...vars import GOOGLE_BOOKS_API_KEY
 
 class BookMetadataClient:
     GOOGLE_BOOKS_API = "https://www.googleapis.com/books/v1/volumes"
-    OPEN_LIBRARY_API = "https://openlibrary.org/"
+    OPEN_LIBRARY_API = "https://openlibrary.org"
     OPEN_WIKI_API = "https://en.wikipedia.org/api/rest_v1/data/citation/mediawiki/"
     USER_AGENT = "ubiblio_bot/1.0 (https://github.com/seanboyce/ubiblio;)"
 
@@ -23,36 +23,30 @@ class BookMetadataClient:
             book = {}
             book["Title"] = raw_book["title"]
             book["Author"] = raw_book["authors"][0]
-            try:
-                book["Summary"] = raw_book["description"]
-            except Exception:
-                book["Summary"] = ""
+            book["Summary"] = raw_book.get("description", "")
             return book, 200
         return {}, response.status_code
 
     def open_library_by_isbn(self, isbn: str) -> tuple[dict[str, str], int]:
-        url = self.OPEN_LIBRARY_API + "isbn/" + str(isbn) + ".json"
+        url = self.OPEN_LIBRARY_API + f"/api/books?bibkeys={isbn}&format=json&jscmd=details"
         headers = {
             "User-Agent": self.USER_AGENT,
             "Accept-Encoding": "gzip",
         }
         response = requests.get(url, headers=headers)
         if response.ok:
-            raw_book = json.loads(response.text)
-            book = {}
-            book["Title"] = raw_book["title"]
-            author_url = str(raw_book["authors"][0]["key"])
-            time.sleep(1)
-            response = requests.get(
-                self.OPEN_LIBRARY_API + author_url + ".json", headers=headers)
-            if response.ok:
-                book["Author"] = json.loads(response.text)["personal_name"]
+            data = response.json()
+            entry = data.get(isbn, {})
+            book_details = entry.get("details", {})
+            book = {
+                "Title": book_details.get("title", ""),
+                "Summary": book_details.get("description", {}).get("value", ""),
+            }
+            authors = book_details.get("authors", [])
+            if len(authors) > 0 and "name" in authors[0]:
+                book["Author"] = authors[0]["name"]
             else:
-                print(response.status_code)
-            try:
-                book["Summary"] = raw_book["description"]["value"]
-            except Exception:
-                book["Summary"] = ""
+                book["Author"] = ""
             return book, 200
         else:
             return {}, response.status_code

--- a/ubiblio/routers/books/book_metadata_client.py
+++ b/ubiblio/routers/books/book_metadata_client.py
@@ -1,0 +1,77 @@
+import json
+import time
+
+import requests
+
+from ...vars import GOOGLE_BOOKS_API_KEY
+
+
+class BookMetadataClient:
+    GOOGLE_BOOKS_API = "https://www.googleapis.com/books/v1/volumes"
+    OPEN_LIBRARY_API = "https://openlibrary.org/"
+    OPEN_WIKI_API = "https://en.wikipedia.org/api/rest_v1/data/citation/mediawiki/"
+    USER_AGENT = "ubiblio_bot/1.0 (https://github.com/seanboyce/ubiblio;)"
+
+    def google_books_by_isbn(self, isbn: str) -> tuple[dict[str, str], int | None]:
+        if not GOOGLE_BOOKS_API_KEY:
+            return {}, None
+        response = requests.get(
+            self.GOOGLE_BOOKS_API,
+            params={"q": f"+isbn:{isbn}", "key": GOOGLE_BOOKS_API_KEY})
+        if response.ok:
+            raw_book = json.loads(response.text)["items"][0]["volumeInfo"]
+            book = {}
+            book["Title"] = raw_book["title"]
+            book["Author"] = raw_book["authors"][0]
+            try:
+                book["Summary"] = raw_book["description"]
+            except Exception:
+                book["Summary"] = ""
+            return book, 200
+        return {}, response.status_code
+
+    def open_library_by_isbn(self, isbn: str) -> tuple[dict[str, str], int]:
+        url = self.OPEN_LIBRARY_API + "isbn/" + str(isbn) + ".json"
+        headers = {
+            "User-Agent": self.USER_AGENT,
+            "Accept-Encoding": "gzip",
+        }
+        response = requests.get(url, headers=headers)
+        if response.ok:
+            raw_book = json.loads(response.text)
+            book = {}
+            book["Title"] = raw_book["title"]
+            author_url = str(raw_book["authors"][0]["key"])
+            time.sleep(1)
+            response = requests.get(
+                self.OPEN_LIBRARY_API + author_url + ".json", headers=headers)
+            if response.ok:
+                book["Author"] = json.loads(response.text)["personal_name"]
+            else:
+                print(response.status_code)
+            try:
+                book["Summary"] = raw_book["description"]["value"]
+            except Exception:
+                book["Summary"] = ""
+            return book, 200
+        else:
+            return {}, response.status_code
+
+    def open_wiki_by_isbn(self, isbn: str) -> tuple[dict[str, str], int]:
+        url = self.OPEN_WIKI_API + "isbn/" + str(isbn) + ".json"
+        headers = {
+            "User-Agent": self.USER_AGENT,
+            "Accept-Encoding": "gzip",
+        }
+        response = requests.get(url, headers=headers)
+        if response.ok:
+            raw_book = json.loads(response.text)[0]
+            book = {}
+            book["Title"] = raw_book["title"]
+            raw_author = raw_book["author"][0]
+            author = " ".join(raw_author).strip()
+            book["Author"] = author
+            book["Summary"] = ""
+            return book, 200
+        else:
+            return {}, response.status_code

--- a/ubiblio/routers/books/service.py
+++ b/ubiblio/routers/books/service.py
@@ -1,0 +1,231 @@
+import json
+import time
+from typing import Any
+
+import requests
+from sqlalchemy.orm import Session
+
+from ... import crud, schemas
+from ...vars import GOOGLE_BOOKS_API_KEY
+
+
+# --------------------------------------------------------------------------
+# External metadata (ISBN / title lookup)
+# --------------------------------------------------------------------------
+def goob_meta(isbn, key):
+    url = "https://www.googleapis.com/books/v1/volumes?q=+isbn:" + str(isbn) + "&key=" + str(key)
+    response = requests.get(url)
+    if response.ok:
+        raw_book = json.loads(response.text)["items"][0]["volumeInfo"]
+        book = {}
+        book["Title"] = raw_book["title"]
+        book["Author"] = raw_book["authors"][0]
+        try:
+            book["Summary"] = raw_book["description"]
+        except Exception:
+            book["Summary"] = ""
+        return book, 200
+    else:
+        return {}, response.status_code
+
+
+def open_lib_meta(isbn):
+    url = "https://openlibrary.org/isbn/" + str(isbn) + ".json"
+    headers = {
+        "User-Agent": "ubiblio_bot/1.0 (https://github.com/seanboyce/ubiblio;)",
+        "Accept-Encoding": "gzip",
+    }
+    response = requests.get(url, headers=headers)
+    if response.ok:
+        raw_book = json.loads(response.text)
+        book = {}
+        book["Title"] = raw_book["title"]
+        author_url = str(raw_book["authors"][0]["key"])
+        url = "https://openlibrary.org" + author_url + ".json"
+        time.sleep(1)
+        response = requests.get(url)
+        if response.ok:
+            book["Author"] = json.loads(response.text)["personal_name"]
+        else:
+            print(response.status_code)
+        try:
+            book["Summary"] = raw_book["description"]["value"]
+        except Exception:
+            book["Summary"] = ""
+        return book, 200
+    else:
+        return {}, response.status_code
+
+
+def open_wiki_meta(isbn):
+    url = "https://en.wikipedia.org/api/rest_v1/data/citation/mediawiki/" + str(isbn)
+    headers = {
+        "User-Agent": "ubiblio_bot/1.0 (https://github.com/seanboyce/ubiblio;)",
+        "Accept-Encoding": "gzip",
+    }
+    response = requests.get(url, headers=headers)
+    if response.ok:
+        raw_book = json.loads(response.text)[0]
+        book = {}
+        book["Title"] = raw_book["title"]
+        raw_author = raw_book["author"][0]
+        author = ""
+        for i in raw_author:
+            author = author + i + " "
+        author = author.strip()
+        book["Author"] = author
+        book["Summary"] = ""
+        return book, 200
+    else:
+        return {}, response.status_code
+
+
+def goob_title(title, key):
+    url = "https://www.googleapis.com/books/v1/volumes?q=+intitle:" + str(title) + "&key=" + str(key)
+    response = requests.get(url)
+    if response.ok:
+        json.loads(response.text)
+        return {}, 200
+    else:
+        return {}, response.status_code
+
+
+def lookup_book_metadata_by_isbn(isbn: str) -> dict[str, Any]:
+    """
+    Resolve ISBN to Title/Author/Summary via Google Books, then Open Library, then Wikipedia.
+    Raises LookupError if no source returns data.
+    """
+    book: dict[str, Any] = {}
+    isbn = isbn.strip()
+    response = 0
+
+    if len(GOOGLE_BOOKS_API_KEY) > 0:
+        try:
+            book, response = goob_meta(isbn, GOOGLE_BOOKS_API_KEY)
+            if response != 200:
+                print("Google Books API failed with response: ")
+                print(response)
+        except Exception:
+            print("Google Books API failed with response: ")
+            print(response)
+
+    try:
+        if len(book) == 0:
+            book, response = open_lib_meta(isbn)
+            if response != 200:
+                print("Open Library API failed with response: ")
+                print(response)
+    except Exception as e:
+        print("Open Library API failed with response: ")
+        print(e)
+
+    try:
+        if len(book) == 0:
+            book, response = open_wiki_meta(isbn)
+            if response != 200:
+                print("Wikipedia API failed with response: ")
+                print(response)
+    except Exception as e:
+        print("Wikipedia API failed with response: ")
+        print(e)
+
+    if len(book) == 0:
+        raise LookupError(f"Book with isbn {isbn} not found!")
+    return book
+
+
+# --------------------------------------------------------------------------
+# Form → schema (book fields)
+# --------------------------------------------------------------------------
+def book_create_from_form(form) -> schemas.BookCreate:
+    return schemas.BookCreate(
+        title=form.title,
+        author=form.author,
+        summary=form.summary,
+        genre=form.genre,
+        library=form.library,
+        shelf=form.shelf,
+        collection=form.collection,
+        notes=form.notes,
+        ISBN=form.ISBN,
+        owned=form.owned,
+        ebook=form.ebook,
+        customField1=form.customField1,
+        customField2=form.customField2,
+        withdrawn=form.withdrawn,
+    )
+
+
+def book_update_from_form(book_id, form) -> schemas.Book:
+    return schemas.Book(
+        id=book_id,
+        title=form.title,
+        author=form.author,
+        summary=form.summary,
+        genre=form.genre,
+        library=form.library,
+        shelf=form.shelf,
+        collection=form.collection,
+        notes=form.notes,
+        ISBN=form.ISBN,
+        owned=form.owned,
+        ebook=form.ebook,
+        customField1=form.customField1,
+        customField2=form.customField2,
+        withdrawn=form.withdrawn,
+    )
+
+
+# --------------------------------------------------------------------------
+# Search serialization
+# --------------------------------------------------------------------------
+def search_books_json(db: Session, title: str, author: str, skip: int, only_ebooks: bool, no_ebooks: bool) -> str | None:
+    from fastapi.encoders import jsonable_encoder
+
+    try:
+        books = crud.searchBooks(db, str(title), str(author), int(skip), bool(only_ebooks), bool(no_ebooks))
+        result = json.dumps(jsonable_encoder(books[0]))
+        data: dict[str, Any] = {"result": result, "count": books[1]}
+        return json.dumps(jsonable_encoder(data))
+    except Exception as e:
+        print(e)
+        return None
+
+
+def search_books_by_author_json(
+    db: Session, author: str, skip: int, only_ebooks: bool, no_ebooks: bool
+) -> str | None:
+    from fastapi.encoders import jsonable_encoder
+
+    try:
+        books = jsonable_encoder(crud.searchBooksbyAuthor(db, str(author), int(skip), bool(only_ebooks), bool(no_ebooks)))
+        result = json.dumps(jsonable_encoder(books[0]))
+        data: dict[str, Any] = {"result": result, "count": books[1]}
+        return json.dumps(jsonable_encoder(data))
+    except Exception as e:
+        print(e)
+        return None
+
+
+def search_books_by_title_json(
+    db: Session, title: str, skip: int, only_ebooks: bool, no_ebooks: bool
+) -> str | None:
+    from fastapi.encoders import jsonable_encoder
+
+    try:
+        books = jsonable_encoder(crud.searchBooksbyTitle(db, str(title), int(skip), bool(only_ebooks), bool(no_ebooks)))
+        result = json.dumps(jsonable_encoder(books[0]))
+        data: dict[str, Any] = {"result": result, "count": books[1]}
+        return json.dumps(jsonable_encoder(data))
+    except Exception as e:
+        print(e)
+        return None
+
+
+def book_create_from_isbn_metadata(book: dict[str, Any], isbn: str) -> schemas.BookCreate:
+    return schemas.BookCreate(
+        title=book["Title"],
+        author=book["Author"],
+        summary=book["Summary"],
+        ISBN=isbn,
+    )

--- a/ubiblio/routers/books/service.py
+++ b/ubiblio/routers/books/service.py
@@ -1,103 +1,15 @@
 import json
-import time
 from typing import Any
 
-import requests
 from sqlalchemy.orm import Session
 
 from ... import crud, schemas
-from ...vars import GOOGLE_BOOKS_API_KEY
+from .book_metadata_client import BookMetadataClient
 
 
 # --------------------------------------------------------------------------
 # External metadata (ISBN / title lookup)
 # --------------------------------------------------------------------------
-
-class BookMetadataClient:
-    GOOGLE_BOOKS_API = "https://www.googleapis.com/books/v1/volumes"
-    OPEN_LIBRARY_API = "https://openlibrary.org/"
-
-    def google_books_by_isbn(self, isbn: str) -> tuple[dict[str, str], int | None]:
-        if not GOOGLE_BOOKS_API_KEY:
-            return {}, None
-        response = requests.get(self.GOOGLE_BOOKS_API, params={
-                                "q": f"isbn:{isbn}", "key": GOOGLE_BOOKS_API_KEY})
-        if response.ok:
-            raw_book = json.loads(response.text)["items"][0]["volumeInfo"]
-            book = {}
-            book["Title"] = raw_book["title"]
-            book["Author"] = raw_book["authors"][0]
-            try:
-                book["Summary"] = raw_book["description"]
-            except Exception:
-                book["Summary"] = ""
-            return book, 200
-        else:
-            return {}, response.status_code
-
-    def open_library_by_isbn(self, isbn: str) -> tuple[dict[str, str], int | None]:
-        url = self.OPEN_LIBRARY_API + "isbn/" + str(isbn) + ".json"
-        headers = {
-            "User-Agent": "ubiblio_bot/1.0 (https://github.com/seanboyce/ubiblio;)",
-            "Accept-Encoding": "gzip",
-        }
-        response = requests.get(url, headers=headers)
-        if response.ok:
-            raw_book = json.loads(response.text)
-            book = {}
-            book["Title"] = raw_book["title"]
-            author_url = str(raw_book["authors"][0]["key"])
-            url = self.OPEN_LIBRARY_API + author_url + ".json"
-            time.sleep(1)
-            response = requests.get(url)
-            if response.ok:
-                book["Author"] = json.loads(response.text)["personal_name"]
-            else:
-                print(response.status_code)
-            try:
-                book["Summary"] = raw_book["description"]["value"]
-            except Exception:
-                book["Summary"] = ""
-            return book, 200
-        else:
-            return {}, response.status_code
-
-
-def open_wiki_meta(isbn):
-    url = "https://en.wikipedia.org/api/rest_v1/data/citation/mediawiki/" + \
-        str(isbn)
-    headers = {
-        "User-Agent": "ubiblio_bot/1.0 (https://github.com/seanboyce/ubiblio;)",
-        "Accept-Encoding": "gzip",
-    }
-    response = requests.get(url, headers=headers)
-    if response.ok:
-        raw_book = json.loads(response.text)[0]
-        book = {}
-        book["Title"] = raw_book["title"]
-        raw_author = raw_book["author"][0]
-        author = ""
-        for i in raw_author:
-            author = author + i + " "
-        author = author.strip()
-        book["Author"] = author
-        book["Summary"] = ""
-        return book, 200
-    else:
-        return {}, response.status_code
-
-
-def goob_title(title, key):
-    url = "https://www.googleapis.com/books/v1/volumes?q=+intitle:" + \
-        str(title) + "&key=" + str(key)
-    response = requests.get(url)
-    if response.ok:
-        json.loads(response.text)
-        return {}, 200
-    else:
-        return {}, response.status_code
-
-
 def lookup_book_metadata_by_isbn(isbn: str) -> dict[str, Any]:
     """
     Resolve ISBN to Title/Author/Summary via Google Books, then Open Library, then Wikipedia.
@@ -129,7 +41,7 @@ def lookup_book_metadata_by_isbn(isbn: str) -> dict[str, Any]:
 
     try:
         if len(book) == 0:
-            book, response = open_wiki_meta(isbn)
+            book, response = client.open_wiki_by_isbn(isbn)
             if response != 200:
                 print("Wikipedia API failed with response: ")
                 print(response)

--- a/ubiblio/routers/books/service.py
+++ b/ubiblio/routers/books/service.py
@@ -12,53 +12,60 @@ from ...vars import GOOGLE_BOOKS_API_KEY
 # --------------------------------------------------------------------------
 # External metadata (ISBN / title lookup)
 # --------------------------------------------------------------------------
-def goob_meta(isbn, key):
-    url = "https://www.googleapis.com/books/v1/volumes?q=+isbn:" + str(isbn) + "&key=" + str(key)
-    response = requests.get(url)
-    if response.ok:
-        raw_book = json.loads(response.text)["items"][0]["volumeInfo"]
-        book = {}
-        book["Title"] = raw_book["title"]
-        book["Author"] = raw_book["authors"][0]
-        try:
-            book["Summary"] = raw_book["description"]
-        except Exception:
-            book["Summary"] = ""
-        return book, 200
-    else:
-        return {}, response.status_code
 
+class BookMetadataClient:
+    GOOGLE_BOOKS_API = "https://www.googleapis.com/books/v1/volumes"
+    OPEN_LIBRARY_API = "https://openlibrary.org/"
 
-def open_lib_meta(isbn):
-    url = "https://openlibrary.org/isbn/" + str(isbn) + ".json"
-    headers = {
-        "User-Agent": "ubiblio_bot/1.0 (https://github.com/seanboyce/ubiblio;)",
-        "Accept-Encoding": "gzip",
-    }
-    response = requests.get(url, headers=headers)
-    if response.ok:
-        raw_book = json.loads(response.text)
-        book = {}
-        book["Title"] = raw_book["title"]
-        author_url = str(raw_book["authors"][0]["key"])
-        url = "https://openlibrary.org" + author_url + ".json"
-        time.sleep(1)
-        response = requests.get(url)
+    def google_books_by_isbn(self, isbn: str) -> tuple[dict[str, str], int | None]:
+        if not GOOGLE_BOOKS_API_KEY:
+            return {}, None
+        response = requests.get(self.GOOGLE_BOOKS_API, params={
+                                "q": f"isbn:{isbn}", "key": GOOGLE_BOOKS_API_KEY})
         if response.ok:
-            book["Author"] = json.loads(response.text)["personal_name"]
+            raw_book = json.loads(response.text)["items"][0]["volumeInfo"]
+            book = {}
+            book["Title"] = raw_book["title"]
+            book["Author"] = raw_book["authors"][0]
+            try:
+                book["Summary"] = raw_book["description"]
+            except Exception:
+                book["Summary"] = ""
+            return book, 200
         else:
-            print(response.status_code)
-        try:
-            book["Summary"] = raw_book["description"]["value"]
-        except Exception:
-            book["Summary"] = ""
-        return book, 200
-    else:
-        return {}, response.status_code
+            return {}, response.status_code
+
+    def open_library_by_isbn(self, isbn: str) -> tuple[dict[str, str], int | None]:
+        url = self.OPEN_LIBRARY_API + "isbn/" + str(isbn) + ".json"
+        headers = {
+            "User-Agent": "ubiblio_bot/1.0 (https://github.com/seanboyce/ubiblio;)",
+            "Accept-Encoding": "gzip",
+        }
+        response = requests.get(url, headers=headers)
+        if response.ok:
+            raw_book = json.loads(response.text)
+            book = {}
+            book["Title"] = raw_book["title"]
+            author_url = str(raw_book["authors"][0]["key"])
+            url = self.OPEN_LIBRARY_API + author_url + ".json"
+            time.sleep(1)
+            response = requests.get(url)
+            if response.ok:
+                book["Author"] = json.loads(response.text)["personal_name"]
+            else:
+                print(response.status_code)
+            try:
+                book["Summary"] = raw_book["description"]["value"]
+            except Exception:
+                book["Summary"] = ""
+            return book, 200
+        else:
+            return {}, response.status_code
 
 
 def open_wiki_meta(isbn):
-    url = "https://en.wikipedia.org/api/rest_v1/data/citation/mediawiki/" + str(isbn)
+    url = "https://en.wikipedia.org/api/rest_v1/data/citation/mediawiki/" + \
+        str(isbn)
     headers = {
         "User-Agent": "ubiblio_bot/1.0 (https://github.com/seanboyce/ubiblio;)",
         "Accept-Encoding": "gzip",
@@ -81,7 +88,8 @@ def open_wiki_meta(isbn):
 
 
 def goob_title(title, key):
-    url = "https://www.googleapis.com/books/v1/volumes?q=+intitle:" + str(title) + "&key=" + str(key)
+    url = "https://www.googleapis.com/books/v1/volumes?q=+intitle:" + \
+        str(title) + "&key=" + str(key)
     response = requests.get(url)
     if response.ok:
         json.loads(response.text)
@@ -98,21 +106,21 @@ def lookup_book_metadata_by_isbn(isbn: str) -> dict[str, Any]:
     book: dict[str, Any] = {}
     isbn = isbn.strip()
     response = 0
+    client = BookMetadataClient()
 
-    if len(GOOGLE_BOOKS_API_KEY) > 0:
-        try:
-            book, response = goob_meta(isbn, GOOGLE_BOOKS_API_KEY)
-            if response != 200:
-                print("Google Books API failed with response: ")
-                print(response)
-        except Exception:
+    try:
+        book, response = client.google_books_by_isbn(isbn)
+        if response is not None and response != 200:
             print("Google Books API failed with response: ")
             print(response)
+    except Exception:
+        print("Google Books API failed with response: ")
+        print(response)
 
     try:
         if len(book) == 0:
-            book, response = open_lib_meta(isbn)
-            if response != 200:
+            book, response = client.open_library_by_isbn(isbn)
+            if response is not None and response != 200:
                 print("Open Library API failed with response: ")
                 print(response)
     except Exception as e:
@@ -183,7 +191,8 @@ def search_books_json(db: Session, title: str, author: str, skip: int, only_eboo
     from fastapi.encoders import jsonable_encoder
 
     try:
-        books = crud.searchBooks(db, str(title), str(author), int(skip), bool(only_ebooks), bool(no_ebooks))
+        books = crud.searchBooks(db, str(title), str(author), int(
+            skip), bool(only_ebooks), bool(no_ebooks))
         result = json.dumps(jsonable_encoder(books[0]))
         data: dict[str, Any] = {"result": result, "count": books[1]}
         return json.dumps(jsonable_encoder(data))
@@ -198,7 +207,8 @@ def search_books_by_author_json(
     from fastapi.encoders import jsonable_encoder
 
     try:
-        books = jsonable_encoder(crud.searchBooksbyAuthor(db, str(author), int(skip), bool(only_ebooks), bool(no_ebooks)))
+        books = jsonable_encoder(crud.searchBooksbyAuthor(
+            db, str(author), int(skip), bool(only_ebooks), bool(no_ebooks)))
         result = json.dumps(jsonable_encoder(books[0]))
         data: dict[str, Any] = {"result": result, "count": books[1]}
         return json.dumps(jsonable_encoder(data))
@@ -213,7 +223,8 @@ def search_books_by_title_json(
     from fastapi.encoders import jsonable_encoder
 
     try:
-        books = jsonable_encoder(crud.searchBooksbyTitle(db, str(title), int(skip), bool(only_ebooks), bool(no_ebooks)))
+        books = jsonable_encoder(crud.searchBooksbyTitle(
+            db, str(title), int(skip), bool(only_ebooks), bool(no_ebooks)))
         result = json.dumps(jsonable_encoder(books[0]))
         data: dict[str, Any] = {"result": result, "count": books[1]}
         return json.dumps(jsonable_encoder(data))


### PR DESCRIPTION
Changes:
* Allow adding using Scan or by ISBN for books without Author #59
* ISBN auto-add feature makes two calls to openLibrary, only one is necessary #54
      
Refactors:
- Rename routers/books.py → routers/books/api.py and add __init__.py (Slim api.py down to routing/HTTP concerns only)
- Move ISBN lookup helpers (goob_meta, open_lib_meta, open_wiki_meta)
  into a new service.py, renamed to snake_case
- Extract service functions into service.py
- Add lots of new test :)